### PR TITLE
feat: direct-USB supported-device registry with resolution-aware rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
 members = ["src-tauri"]
 resolver = "2"
+
+[profile.release]
+opt-level = "z"     # optimize for size
+lto = true          # link-time optimization across crates
+codegen-units = 1   # better optimization at cost of compile time
+panic = "abort"     # drop unwinding tables/landing pads
+strip = true        # strip symbols from binary

--- a/README.md
+++ b/README.md
@@ -152,11 +152,29 @@ sensor_12="Network: Intel Ethernet Controller I225-V;Current UP rate"
 label_12="NET ^"
 unit_12="mb/s"
 convert_12="kb/mb"
+icon_12="net"  # Optional builtin icon, Direct USB mode only (see below)
 
 sensor_13="Network: Intel Ethernet Controller I225-V;Current DL rate"
 label_13="NET v"
 unit_13="mb/s"
 convert_13="kb/mb"
+```
+
+#### Sensor Icons (Direct USB mode)
+
+In **Direct USB (HID)** mode the display is drawn as a bitmap, so each sensor can
+show a small icon before its value via the optional `icon_N` key (or the **Icon**
+dropdown in the settings window). Icons are ignored in SteelSeries GG mode, which
+only renders text.
+
+Available builtin icon names: `cpu`, `gpu`, `mem`, `temp`, `fan`, `clock`,
+`disk`, `power`, `usage`, `net`. Leave empty for no icon.
+
+```ini
+sensor_0="CPU [#0]: AMD Ryzen 9 5950X;CPU (Tctl/Tdie)"
+label_0=""
+unit_0="°"
+icon_0="cpu"
 ```
 
 #### Custom Mode Output Examples

--- a/docs/superpowers/plans/2026-05-29-conditional-pages.md
+++ b/docs/superpowers/plans/2026-05-29-conditional-pages.md
@@ -1,0 +1,846 @@
+# Conditional Pages (Process-Gated) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let each custom page join the OLED rotation only while a named process is running (e.g. show an FPS page only while a game is open).
+
+**Architecture:** A new `process_watch` module caches the set of running exe names and exposes pure matching helpers. The daemon computes the set of "active" pages each tick and rotates only through those, falling back to all pages when none qualify. The per-page condition is stored as a `show_when_running` key in each `PAGE{i}.Sensors` ini section, carried on `AppConfig.page_conditions`, and edited via a text field in the settings GUI.
+
+**Tech Stack:** Rust, Tauri 2, `winapi` (toolhelp process enumeration), `rust-ini`, HTML/JS settings UI.
+
+---
+
+## File Structure
+
+- **Create** `src-tauri/src/process_watch.rs` — `ProcessWatcher` (cached running-process set + periodic refresh) and the pure helpers `parse_condition`, `page_is_active`, `active_pages`.
+- **Modify** `src-tauri/Cargo.toml` — add `tlhelp32` to the `winapi` features.
+- **Modify** `src-tauri/src/main.rs` — declare `mod process_watch;`; extend the inline `AppConfig` literal.
+- **Modify** `src-tauri/src/settings.rs` — add `page_conditions` field + `#[serde(default)]`; read `show_when_running` in `from_ini`.
+- **Modify** `src-tauri/src/gui.rs` — write `show_when_running` in `apply_pages_sections`; extend the test `AppConfig` literal.
+- **Modify** `src-tauri/src/daemon.rs` — hold a `ProcessWatcher`; rework `next_page_counter` + the tick rotation to use active pages; extend the test `AppConfig` literal.
+- **Modify** `src-tauri/src/state.rs` — extend the mock `AppConfig` literal.
+- **Modify** `src-tauri/ui/index.html` — per-page "Show only while running (exe)" input.
+
+> **Note on field-addition ordering:** Adding `page_conditions` to `AppConfig` breaks every struct-literal construction at once. Task 2 therefore adds the field **and** updates all four literals (settings/daemon/gui/main/state) in a single task so the build stays green.
+
+---
+
+## Task 1: Pure process-matching helpers
+
+**Files:**
+- Create: `src-tauri/src/process_watch.rs`
+- Modify: `src-tauri/src/main.rs` (add `mod process_watch;`)
+
+- [ ] **Step 1: Declare the module**
+
+In `src-tauri/src/main.rs`, add alongside the other `mod` lines (after line 23, `mod media;`):
+
+```rust
+mod process_watch;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src-tauri/src/process_watch.rs` with ONLY the pure helpers' tests and empty stubs:
+
+```rust
+use std::collections::HashSet;
+
+/// Split a `show_when_running` value into normalized exe-name tokens:
+/// comma-separated, trimmed, lowercased, empties dropped.
+pub fn parse_condition(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// A page is active if it has no condition, or if any of its tokens is in the
+/// running set. `running` must contain lowercased exe filenames.
+pub fn page_is_active(condition: &str, running: &HashSet<String>) -> bool {
+    let tokens = parse_condition(condition);
+    if tokens.is_empty() {
+        return true;
+    }
+    tokens.iter().any(|t| running.contains(t))
+}
+
+/// Indices of pages that should be shown. `conditions[i]` is the raw
+/// `show_when_running` for page `i` (missing entries treated as unconditional).
+/// If nothing qualifies, returns all indices (never leaves the screen empty).
+pub fn active_pages(
+    conditions: &[String],
+    page_count: usize,
+    running: &HashSet<String>,
+) -> Vec<usize> {
+    let mut active: Vec<usize> = (0..page_count)
+        .filter(|&i| {
+            let cond = conditions.get(i).map(|s| s.as_str()).unwrap_or("");
+            page_is_active(cond, running)
+        })
+        .collect();
+    if active.is_empty() {
+        active = (0..page_count).collect();
+    }
+    active
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_lowercase()).collect()
+    }
+
+    #[test]
+    fn parse_condition_trims_lowercases_and_drops_empties() {
+        assert_eq!(parse_condition(" Game.exe ,, LAUNCHER.exe ,"),
+                   vec!["game.exe".to_string(), "launcher.exe".to_string()]);
+        assert!(parse_condition("   ").is_empty());
+        assert!(parse_condition("").is_empty());
+    }
+
+    #[test]
+    fn page_is_active_empty_condition_is_always_true() {
+        assert!(page_is_active("", &set(&[])));
+        assert!(page_is_active("  ", &set(&["x.exe"])));
+    }
+
+    #[test]
+    fn page_is_active_matches_case_insensitively() {
+        assert!(page_is_active("Game.exe", &set(&["game.exe"])));
+        assert!(!page_is_active("game.exe", &set(&["other.exe"])));
+    }
+
+    #[test]
+    fn page_is_active_any_token_matches() {
+        assert!(page_is_active("a.exe, b.exe", &set(&["b.exe"])));
+        assert!(!page_is_active("a.exe, b.exe", &set(&["c.exe"])));
+    }
+
+    #[test]
+    fn active_pages_mixes_conditional_and_unconditional() {
+        // page0 unconditional, page1 needs game.exe (running), page2 needs x.exe (not)
+        let conds = vec!["".to_string(), "game.exe".to_string(), "x.exe".to_string()];
+        assert_eq!(active_pages(&conds, 3, &set(&["game.exe"])), vec![0, 1]);
+    }
+
+    #[test]
+    fn active_pages_all_unconditional_returns_all() {
+        let conds = vec!["".to_string(), "".to_string()];
+        assert_eq!(active_pages(&conds, 2, &set(&[])), vec![0, 1]);
+    }
+
+    #[test]
+    fn active_pages_falls_back_to_all_when_none_match() {
+        let conds = vec!["a.exe".to_string(), "b.exe".to_string()];
+        assert_eq!(active_pages(&conds, 2, &set(&["c.exe"])), vec![0, 1]);
+    }
+
+    #[test]
+    fn active_pages_tolerates_short_conditions_slice() {
+        // Only one condition provided but two pages: page1 treated as unconditional.
+        let conds = vec!["x.exe".to_string()];
+        assert_eq!(active_pages(&conds, 2, &set(&["x.exe"])), vec![0, 1]);
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `cargo test process_watch::tests`
+Expected: PASS (the helpers are already written; this task is the pure core, no Windows code yet).
+
+> If the package name differs, use `cargo test process_watch::tests` from `src-tauri/`. Confirm with `cargo test 2>&1 | head` if unsure.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/process_watch.rs src-tauri/src/main.rs
+git commit -m "feat(pages): add pure process-matching helpers"
+```
+
+---
+
+## Task 2: Add `page_conditions` to AppConfig and read it from ini
+
+**Files:**
+- Modify: `src-tauri/src/settings.rs:84-105` (struct + default fn), `src-tauri/src/settings.rs:185-243` (`from_ini` body)
+- Modify (literals): `src-tauri/src/daemon.rs:855`, `src-tauri/src/gui.rs:469`, `src-tauri/src/main.rs:604`, `src-tauri/src/state.rs:98`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `settings.rs`'s `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn test_appconfig_reads_show_when_running_per_page() {
+        let mut conf = Ini::new();
+        conf.with_section(Some("Main"))
+            .set("style", "Custom")
+            .set("pages", "2");
+        conf.with_section(Some("PAGE1.Sensors"))
+            .set("sensor_0", "CPU;Temp");
+        conf.with_section(Some("PAGE2.Sensors"))
+            .set("show_when_running", "game.exe")
+            .set("sensor_0", "GPU;Framerate");
+
+        let config = AppConfig::from_ini(&conf).unwrap();
+        assert_eq!(config.page_conditions.len(), 2);
+        assert_eq!(config.page_conditions[0], "");
+        assert_eq!(config.page_conditions[1], "game.exe");
+    }
+
+    #[test]
+    fn test_appconfig_page_conditions_default_empty_when_absent() {
+        let mut conf = Ini::new();
+        conf.with_section(Some("Main"))
+            .set("style", "Custom")
+            .set("pages", "1");
+        conf.with_section(Some("PAGE1.Sensors")).set("sensor_0", "CPU;Temp");
+        let config = AppConfig::from_ini(&conf).unwrap();
+        assert_eq!(config.page_conditions, vec!["".to_string()]);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test test_appconfig_reads_show_when_running_per_page`
+Expected: FAIL to compile — `no field page_conditions on type AppConfig`.
+
+- [ ] **Step 3: Add the field and default**
+
+In `src-tauri/src/settings.rs`, add to the `AppConfig` struct (after the `font_sizes` field, around line 100):
+
+```rust
+    #[serde(default)]
+    pub page_conditions: Vec<String>,
+```
+
+- [ ] **Step 4: Populate it in `from_ini`**
+
+In `AppConfig::from_ini`, the returned `Ok(Self { ... })` builds `custom_sensors` from a `for i in 1..=pages` loop. Add a sibling field that reads the condition per page. Insert this field into the `Ok(Self { ... })` literal (after `font_sizes,`):
+
+```rust
+            page_conditions: {
+                let mut conds = Vec::with_capacity(pages);
+                for i in 1..=pages {
+                    let cond = config
+                        .section(Some(format!("PAGE{}.Sensors", i)))
+                        .and_then(|s| s.get("show_when_running"))
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    conds.push(cond);
+                }
+                conds
+            },
+```
+
+- [ ] **Step 5: Fix the four struct literals**
+
+`AppConfig` is also built by hand in tests/mocks. In EACH of these, add the line `page_conditions: Vec::new(),` immediately before the `font_sizes:` line:
+
+- `src-tauri/src/daemon.rs:855` (the `base_config()` helper)
+- `src-tauri/src/gui.rs:469` (the `base_config()` helper)
+- `src-tauri/src/main.rs:604` (the `SharedState::new(AppConfig { ... })`)
+- `src-tauri/src/state.rs:98` (the `mock_config()` helper)
+
+Example (daemon.rs), the literal becomes:
+
+```rust
+            custom_sensors: Vec::new(),
+            weather: WeatherConfig::default(),
+            page_conditions: Vec::new(),
+            font_sizes: [crate::render::FontSize::Medium; crate::consts::DISPLAY_LINES],
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p hwinfo-steelseries`
+Expected: PASS, build green (all literals updated).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/settings.rs src-tauri/src/daemon.rs src-tauri/src/gui.rs src-tauri/src/main.rs src-tauri/src/state.rs
+git commit -m "feat(pages): add page_conditions to AppConfig, read show_when_running"
+```
+
+---
+
+## Task 3: Persist `show_when_running` when saving config (GUI write path)
+
+**Files:**
+- Modify: `src-tauri/src/gui.rs:198-225` (`apply_pages_sections`)
+- Test: `src-tauri/src/gui.rs` test module
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `gui.rs`'s test module (near `test_apply_pages_sections_writes_sensors`):
+
+```rust
+    #[test]
+    fn test_apply_pages_sections_writes_show_when_running() {
+        let mut config = base_config();
+        config.custom_sensors = vec![
+            vec![sensor("CPU;Temp")],
+            vec![sensor("GPU;Framerate")],
+        ];
+        config.page_conditions = vec!["".to_string(), "game.exe".to_string()];
+
+        let mut ini = Ini::new();
+        apply_pages_sections(&mut ini, &config);
+
+        // Unconditional page omits the key.
+        assert!(ini
+            .section(Some("PAGE1.Sensors"))
+            .unwrap()
+            .get("show_when_running")
+            .is_none());
+        // Conditional page writes it.
+        assert_eq!(
+            ini.section(Some("PAGE2.Sensors")).unwrap().get("show_when_running"),
+            Some("game.exe")
+        );
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test test_apply_pages_sections_writes_show_when_running`
+Expected: FAIL — assertion on `PAGE2.Sensors` `show_when_running` is `None`.
+
+- [ ] **Step 3: Implement the write**
+
+In `apply_pages_sections`, inside the `for (i, page) in config.custom_sensors.iter().enumerate()` loop, right after `let mut section = ini.with_section(Some(section_name));`, add:
+
+```rust
+            if let Some(cond) = config.page_conditions.get(i) {
+                let cond = cond.trim();
+                if !cond.is_empty() {
+                    section.set("show_when_running", cond);
+                }
+            }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test test_apply_pages_sections_writes_show_when_running`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/gui.rs
+git commit -m "feat(pages): persist show_when_running when saving config"
+```
+
+---
+
+## Task 4: Toolhelp process enumeration + `ProcessWatcher`
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml:22` (winapi features)
+- Modify: `src-tauri/src/process_watch.rs` (add `ProcessWatcher` + enumeration)
+
+- [ ] **Step 1: Add the winapi feature**
+
+In `src-tauri/Cargo.toml`, change line 22 to include `tlhelp32`:
+
+```toml
+winapi = {version="0.3", features=["handleapi", "memoryapi", "winnt", "wincon", "winuser", "tlhelp32"]}
+```
+
+- [ ] **Step 2: Write the failing test for the watcher's pure behavior**
+
+Add to the `tests` module in `process_watch.rs`:
+
+```rust
+    #[test]
+    fn watcher_starts_empty_and_accepts_injected_set() {
+        let mut w = ProcessWatcher::new();
+        assert!(w.running().is_empty());
+        w.set_running_for_test(set(&["game.exe"]));
+        assert!(w.running().contains("game.exe"));
+    }
+
+    #[test]
+    fn watcher_refresh_is_rate_limited() {
+        // After an injected set, an immediate refresh at a near tick must NOT
+        // re-enumerate (which would clobber the injected value within the window).
+        let mut w = ProcessWatcher::new();
+        w.set_running_for_test(set(&["sentinel.exe"]));
+        w.refresh(1); // first refresh records the tick but our window blocks re-enum? See note.
+        // The injected sentinel proves no enumeration replaced it within the window.
+        // (Enumeration only runs when due; set_running_for_test seeds last_refresh_tick.)
+        assert!(w.running().contains("sentinel.exe"));
+    }
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cargo test watcher_starts_empty`
+Expected: FAIL to compile — `ProcessWatcher` not found.
+
+- [ ] **Step 4: Implement `ProcessWatcher` + enumeration**
+
+Add to the top of `process_watch.rs` (after the existing `use` line):
+
+```rust
+/// Re-enumerate running processes at most this many daemon ticks apart.
+/// TICK_RATE is 500 ms, so 4 ticks ≈ 2 seconds.
+const REFRESH_TICKS: isize = 4;
+
+/// Caches the set of running exe filenames (lowercased) and refreshes it on a
+/// coarse interval so the per-tick page-gating check is cheap.
+pub struct ProcessWatcher {
+    running: HashSet<String>,
+    last_refresh_tick: Option<isize>,
+}
+
+impl ProcessWatcher {
+    pub fn new() -> Self {
+        Self {
+            running: HashSet::new(),
+            last_refresh_tick: None,
+        }
+    }
+
+    pub fn running(&self) -> &HashSet<String> {
+        &self.running
+    }
+
+    /// Refresh the cache if at least `REFRESH_TICKS` have elapsed since the last
+    /// enumeration. `tick` is the daemon's monotonic tick counter.
+    pub fn refresh(&mut self, tick: isize) {
+        let due = match self.last_refresh_tick {
+            None => true,
+            Some(t) => (tick - t).abs() >= REFRESH_TICKS,
+        };
+        if !due {
+            return;
+        }
+        if let Some(set) = enumerate_processes() {
+            self.running = set;
+        }
+        self.last_refresh_tick = Some(tick);
+    }
+
+    #[cfg(test)]
+    pub fn set_running_for_test(&mut self, names: HashSet<String>) {
+        self.running = names;
+        self.last_refresh_tick = Some(0);
+    }
+}
+
+impl Default for ProcessWatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Enumerate running processes via the Win32 toolhelp snapshot. Returns
+/// lowercased exe filenames, or `None` if the snapshot could not be taken.
+#[cfg(windows)]
+fn enumerate_processes() -> Option<HashSet<String>> {
+    use std::os::windows::ffi::OsStringExt;
+    use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
+    use winapi::um::tlhelp32::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            return None;
+        }
+
+        let mut entry: PROCESSENTRY32W = std::mem::zeroed();
+        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+
+        let mut set = HashSet::new();
+        if Process32FirstW(snapshot, &mut entry) != 0 {
+            loop {
+                let len = entry
+                    .szExeFile
+                    .iter()
+                    .position(|&c| c == 0)
+                    .unwrap_or(entry.szExeFile.len());
+                let name = std::ffi::OsString::from_wide(&entry.szExeFile[..len])
+                    .to_string_lossy()
+                    .to_lowercase();
+                if !name.is_empty() {
+                    set.insert(name);
+                }
+                if Process32NextW(snapshot, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snapshot);
+        Some(set)
+    }
+}
+
+#[cfg(not(windows))]
+fn enumerate_processes() -> Option<HashSet<String>> {
+    None
+}
+```
+
+> Note: `set_running_for_test` seeds `last_refresh_tick = Some(0)`, so the rate-limit test's `refresh(1)` is within the window (`|1-0| < 4`) and returns early without enumerating — the injected sentinel survives, proving the gate works.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cargo test process_watch`
+Expected: PASS (all pure + watcher tests).
+
+- [ ] **Step 6: Verify the crate builds with the new winapi feature**
+
+Run: `cargo build`
+Expected: builds clean (no missing-symbol errors from toolhelp).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/src/process_watch.rs
+git commit -m "feat(pages): add ProcessWatcher with toolhelp enumeration"
+```
+
+---
+
+## Task 5: Rotate over active pages in the daemon
+
+**Files:**
+- Modify: `src-tauri/src/daemon.rs:298-309` (`next_page_counter`), `src-tauri/src/daemon.rs:396-441` (struct + `new`), `src-tauri/src/daemon.rs:678-705` (tick rotation)
+- Test: `src-tauri/src/daemon.rs` test module
+
+- [ ] **Step 1: Write the failing tests for the reworked `next_page_counter`**
+
+The signature's third param changes meaning from `pages` to `active_len`. Replace the existing `next_page_counter` tests (`test_next_page_counter_*`) with these (they assert the new clamp behavior; numeric results are unchanged when the active set is full):
+
+```rust
+    #[test]
+    fn test_next_page_counter_advances_at_interval() {
+        // TICK_RATE = 500 → ticks_per_second = 2 → interval = page_time*2
+        assert_eq!(next_page_counter(10, 5, 3, 0), 1);
+        assert_eq!(next_page_counter(20, 5, 3, 1), 2);
+        assert_eq!(next_page_counter(30, 5, 3, 2), 0); // wraps
+    }
+
+    #[test]
+    fn test_next_page_counter_keeps_when_not_at_boundary() {
+        assert_eq!(next_page_counter(5, 5, 3, 0), 0);
+        assert_eq!(next_page_counter(1, 5, 3, 1), 1);
+    }
+
+    #[test]
+    fn test_next_page_counter_zero_tick_does_not_advance() {
+        assert_eq!(next_page_counter(0, 5, 3, 0), 0);
+    }
+
+    #[test]
+    fn test_next_page_counter_handles_zero_active_or_page_time() {
+        assert_eq!(next_page_counter(10, 5, 0, 0), 0);
+        assert_eq!(next_page_counter(10, 0, 3, 1), 1);
+        assert_eq!(next_page_counter(10, -1, 3, 1), 1);
+    }
+
+    #[test]
+    fn test_next_page_counter_clamps_when_active_set_shrinks() {
+        // current points past the end (active set shrank from 3 to 2) → clamp.
+        assert_eq!(next_page_counter(5, 5, 2, 2), 1); // not a boundary: clamp only
+        assert_eq!(next_page_counter(10, 5, 2, 2), 0); // boundary: clamp(→1) then advance→0
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test test_next_page_counter_clamps_when_active_set_shrinks`
+Expected: FAIL — current impl does not clamp (`next_page_counter(5,5,2,2)` returns 2).
+
+- [ ] **Step 3: Rework `next_page_counter`**
+
+Replace the existing function (`src-tauri/src/daemon.rs:298-309`) with:
+
+```rust
+/// Advance the rotation index within the *active* page set. `current` is an
+/// index into the active list; it is clamped when the active set shrinks (e.g.
+/// a gated page drops out mid-cycle) and advanced once per `page_time` window.
+fn next_page_counter(i: isize, page_time: isize, active_len: usize, current: usize) -> usize {
+    if active_len == 0 {
+        return 0;
+    }
+    let current = current.min(active_len - 1);
+    if page_time <= 0 {
+        return current;
+    }
+    let ticks_per_second = 1000 / TICK_RATE as isize;
+    let interval = page_time * ticks_per_second;
+    if interval > 0 && i != 0 && i % interval == 0 {
+        (current + 1) % active_len
+    } else {
+        current
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test test_next_page_counter`
+Expected: PASS (all five tests).
+
+- [ ] **Step 5: Add the watcher to the `Daemon` struct**
+
+In `src-tauri/src/daemon.rs`:
+
+Add the import near the other `use crate::...` lines (top of file):
+
+```rust
+use crate::process_watch::{active_pages, ProcessWatcher};
+```
+
+Add a field to `struct Daemon` (after `weather_reader`, around line 414):
+
+```rust
+    process_watcher: ProcessWatcher,
+```
+
+Initialize it in `Daemon::new`'s returned `Self { ... }` (after `weather_reader,`, around line 437):
+
+```rust
+            process_watcher: ProcessWatcher::new(),
+```
+
+- [ ] **Step 6: Rework the tick rotation to use active pages**
+
+In `Daemon::tick`, replace the custom-mode rotation block (`src-tauri/src/daemon.rs:678-690`, the `if !self.config.is_summary { let next = next_page_counter(...) ... }`) and the subsequent `build_display_value` / `page_event_name` usage. Replace from the rotation block down to the `oled.trigger_frame(...)` call with:
+
+```rust
+        // Advance the rotation over the *active* (process-gated) page set.
+        let display_page = if self.config.is_summary {
+            0
+        } else {
+            self.process_watcher.refresh(self.i.0);
+            let active = active_pages(
+                &self.config.page_conditions,
+                self.config.pages,
+                self.process_watcher.running(),
+            );
+            self.page_counter =
+                next_page_counter(self.i.0, self.config.page_time, active.len(), self.page_counter);
+            let resolved = active.get(self.page_counter).copied().unwrap_or(0);
+            debug!(
+                "Active pages {:?}, rotation idx {} → page {}",
+                active,
+                self.page_counter,
+                resolved + 1
+            );
+            resolved
+        };
+
+        let value = build_display_value(
+            &self.config,
+            hwinfo,
+            &self.pages_vec,
+            display_page,
+            &mut self.mouse_battery_reader,
+            &mut self.media_reader,
+            &self.weather_reader,
+            self.hid_api.as_ref(),
+        )?;
+
+        let buffer = value_to_oled_buffer(&value, &self.config.font_sizes);
+        let event_name = page_event_name(display_page);
+        oled.trigger_frame(&event_name, self.i.0, &value, &buffer)?;
+```
+
+> This removes the old standalone `let value = build_display_value(... self.page_counter ...)`, `let event_name = page_event_name(self.page_counter)` lines — they are replaced by the block above. `page_counter` now indexes the active list; `display_page` is the real page index used everywhere downstream.
+
+- [ ] **Step 7: Write an integration test for gated rotation**
+
+Add to the `daemon.rs` test module:
+
+```rust
+    #[test]
+    fn test_daemon_tick_skips_unmatched_conditional_page() {
+        let mut d = daemon_for_tests();
+        d.config.is_summary = false;
+        d.config.pages = 2;
+        d.config.page_time = 1;
+        // Page 2 gated on a process that is NOT running.
+        d.config.page_conditions = vec!["".to_string(), "definitely-not-running.exe".to_string()];
+        let mut hw = build_hwinfo(&[("S", "R", 1.0)]);
+        hw.bypass_pull_for_test = true;
+        d.hwinfo = Some(hw);
+        install_mock_driver(&mut d);
+        d.pages_vec = vec![ini::Properties::new(), ini::Properties::new()];
+        // Force the watcher to a known empty set so page 2 stays gated out.
+        d.process_watcher.set_running_for_test(std::collections::HashSet::new());
+
+        // Run several ticks across multiple rotation intervals.
+        for _ in 0..6 {
+            let _ = d.tick();
+        }
+        // Only page 1 is active → rotation index never leaves the single active page.
+        assert_eq!(d.page_counter, 0);
+    }
+```
+
+- [ ] **Step 8: Run the daemon tests to verify pass**
+
+Run: `cargo test daemon`
+Expected: PASS, including the existing happy-path/custom-mode rotation tests (which use empty `page_conditions` → all pages active → unchanged behavior).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src-tauri/src/daemon.rs
+git commit -m "feat(pages): rotate only over process-active pages"
+```
+
+---
+
+## Task 6: Settings GUI field for the per-page condition
+
+**Files:**
+- Modify: `src-tauri/ui/index.html` (page-tab UI around lines 420-460 and the per-page render/save logic near lines 837-1060)
+
+> This task is UI wiring with no Rust test harness (the project has no JS tests). Verify manually by launching the settings window.
+
+- [ ] **Step 1: Add the input element**
+
+In `src-tauri/ui/index.html`, find the page controls block (near the `page-time` input, ~line 423). Add, just below the page-time row:
+
+```html
+        <label for="page-condition">Show only while running (exe)</label>
+        <input type="text" id="page-condition" placeholder="e.g. game.exe (blank = always)">
+```
+
+- [ ] **Step 2: Ensure the config object always carries `page_conditions`**
+
+In the JS, find `ensurePage(idx)` (~line 511). After it ensures `config.custom_sensors[idx]` exists, also ensure the conditions array:
+
+```javascript
+        function ensurePageCondition(idx) {
+            if (!Array.isArray(config.page_conditions)) config.page_conditions = [];
+            while (config.page_conditions.length <= idx) config.page_conditions.push('');
+        }
+```
+
+- [ ] **Step 3: Load the field when switching/rendering a page**
+
+Find where the active page is rendered (the page-tab click handler / `renderLines`, ~line 848 and ~line 894 where config loads). Add a helper and call it whenever `activePage` changes and on initial config load:
+
+```javascript
+        function renderPageCondition() {
+            ensurePageCondition(activePage);
+            const el = document.getElementById('page-condition');
+            if (el) el.value = config.page_conditions[activePage] || '';
+        }
+```
+
+Call `renderPageCondition();` in the page-tab click handler (right after `activePage = i;`) and once after the config is loaded (near where `document.getElementById('pages').value = config.pages` is set, ~line 894).
+
+- [ ] **Step 4: Write the field back on edit**
+
+Where the other inputs register `change` listeners (~line 1026-1040), add:
+
+```javascript
+        document.getElementById('page-condition').addEventListener('input', () => {
+            ensurePageCondition(activePage);
+            config.page_conditions[activePage] = document.getElementById('page-condition').value.trim();
+        });
+```
+
+- [ ] **Step 5: Include it in the saved config**
+
+Find the save handler that assembles the config before `invoke('save_config', ...)` (~line 1057, where `config.pages` / `config.page_time` are read from the DOM). Ensure `config.page_conditions` is sized to the page count so trailing pages persist correctly:
+
+```javascript
+                for (let i = 0; i < config.pages; i++) ensurePageCondition(i);
+                config.page_conditions = config.page_conditions.slice(0, config.pages);
+```
+
+- [ ] **Step 6: Manual verification**
+
+Run: `cargo tauri dev` (or the project's normal dev launch), open Settings → Custom mode.
+Expected:
+- Each page tab shows the "Show only while running (exe)" field.
+- Typing `game.exe` on page 2, saving, then reopening shows the value retained.
+- Inspect `conf.ini`: `[PAGE2.Sensors]` contains `show_when_running=game.exe`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/ui/index.html
+git commit -m "feat(pages): settings UI field for per-page process condition"
+```
+
+---
+
+## Task 7: Documentation + full verification
+
+**Files:**
+- Modify: `README.md` (custom-mode configuration section), `CLAUDE.md` (Special Sensor Features / config notes)
+
+- [ ] **Step 1: Document the feature in README.md**
+
+Add a short subsection under the Custom Mode configuration docs describing `show_when_running`:
+
+```markdown
+#### Conditional Pages
+
+Add `show_when_running` to any `[PAGEn.Sensors]` section to show that page only
+while a process is running. Useful for a game-only FPS page.
+
+```ini
+[PAGE2.Sensors]
+show_when_running = game.exe
+sensor_0 = ...
+```
+
+- Case-insensitive, matches the exe filename.
+- Comma-separated for multiple matches: `show_when_running = game.exe, launcher.exe`.
+- Pages with no `show_when_running` always show.
+- If no conditional page currently matches, all pages rotate as a fallback.
+```
+
+- [ ] **Step 2: Note it in CLAUDE.md**
+
+Under "Configuration System" → "Custom Mode", add a bullet:
+
+```markdown
+- **Conditional pages**: `show_when_running="exe[,exe...]"` in a PAGE section gates
+  that page to only appear while a matching process runs (see `process_watch.rs`).
+```
+
+- [ ] **Step 3: Full test + lint sweep**
+
+Run: `cargo test -p hwinfo-steelseries`
+Expected: all PASS.
+
+Run: `cargo clippy -- -D warnings`
+Expected: no warnings (matches the repo's clippy-clean convention).
+
+Run: `cargo fmt`
+Expected: no diff after formatting (or commit the formatting).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "docs: document conditional (process-gated) pages"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** config format → Tasks 2/3/6; ProcessWatcher + pure helpers → Tasks 1/4; daemon rotation + fallback → Task 5; GUI field → Task 6; testing → embedded per task; docs → Task 7. All spec sections covered.
+- **Type consistency:** `active_pages(conditions, page_count, running)`, `page_is_active(condition, running)`, `parse_condition(raw)`, `ProcessWatcher::{new, running, refresh, set_running_for_test}`, and `next_page_counter(i, page_time, active_len, current)` are used identically wherever referenced.
+- **Fallback:** implemented once, in `active_pages` (returns all indices when nothing qualifies), and relied on by the daemon — no duplicate fallback logic.
+```

--- a/docs/superpowers/plans/2026-06-11-usb-device-registry.md
+++ b/docs/superpowers/plans/2026-06-11-usb-device-registry.md
@@ -1,0 +1,1246 @@
+# Direct-USB Supported-Device Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single hardcoded direct-USB packet format with a static registry of supported devices (PIDs, screen size, packet protocol), make the render pipeline resolution-aware, and surface unsupported devices in the GUI as "not yet supported".
+
+**Architecture:** A new `devices.rs` module owns a compile-time `SUPPORTED_DEVICES` table and a `Protocol` enum whose `build_packets()` produces the full HID frame for a device. `OledBuffer` gains runtime `width`/`height`. `connect.rs` only connects registry devices; the daemon carries the matched registry entry in `OledClient::Hid` and renders at its dimensions. Frame/preview payloads carry `{width, height, pixels}` so the GUI canvas adapts.
+
+**Tech Stack:** Rust (Tauri app in `src-tauri/`), `hidapi`, `embedded-graphics`, vanilla-JS frontend in `src-tauri/ui/index.html`.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-usb-device-registry-design.md`
+
+**Notes for the implementer:**
+- All `cargo` commands run from the repo root (`C:\Users\Ryan\code\HWiNFO-SteelSeries`).
+- `rtk` (token-filter wrapper) is NOT installed on this machine — use plain `cargo`/`git`.
+- The spec says "the settings.rs wizard lists supported devices only" — verified during planning: the console wizard never enumerates devices (it only asks GameSense vs Direct USB; device selection happens in the GUI). **No wizard change is needed.**
+- Verified protocol facts (apex-tux `apex-hardware/src/usb.rs`):
+  - PID→model: `0x1610` Apex Pro, `0x1612` Apex 7, `0x1614` Apex Pro TKL, `0x1618` Apex 7 TKL, `0x161C` Apex 5 — all "Legacy" protocol, 128×40.
+  - Legacy packet: one 641-byte feature report = `0x61` + 640-byte SSD1306 page-major bitmap.
+  - Gen3 PIDs (`0x1640`, `0x1644`, `0x1646`) are out of scope.
+
+---
+
+### Task 1: Resolution-aware `OledBuffer`
+
+`OledBuffer` stores `width`/`height` and a `Vec<u8>` instead of `[u8; 1024]`. Constructor becomes `new(width, height)`. Internal layout stays column-major pages (per column, `height/8` bytes, bit 0 = top of page).
+
+**Files:**
+- Modify: `src-tauri/src/render.rs` (struct + impls + every `OledBuffer::new()` in tests)
+- Modify: `src-tauri/src/daemon.rs` (call sites + `OledBuffer { data: ... }` literals)
+- Modify: `src-tauri/src/gui.rs` (test call site)
+- Modify: `src-tauri/src/state.rs` (init call site)
+
+- [ ] **Step 1: Write failing tests for the new constructor and 128×40 bounds**
+
+Add to the `tests` module in `src-tauri/src/render.rs`:
+
+```rust
+#[test]
+fn test_new_sizes_buffer_for_dimensions() {
+    let b64 = OledBuffer::new(128, 64);
+    assert_eq!(b64.width, 128);
+    assert_eq!(b64.height, 64);
+    assert_eq!(b64.data.len(), 128 * 64 / 8); // 1024
+
+    let b40 = OledBuffer::new(128, 40);
+    assert_eq!(b40.data.len(), 128 * 40 / 8); // 640
+}
+
+#[test]
+fn test_set_pixel_respects_instance_bounds() {
+    let mut b40 = OledBuffer::new(128, 40);
+    b40.set_pixel(0, 39, true); // in bounds
+    b40.set_pixel(0, 40, true); // out of bounds for 40-tall: no-op, no panic
+    b40.set_pixel(127, 0, true);
+    b40.set_pixel(128, 0, true); // no-op
+
+    // (0, 39): column 0, page 4, bit 7
+    assert_eq!(b40.data[4], 0x80);
+    // (127, 0): column 127, page 0, bit 0; 5 pages per column
+    assert_eq!(b40.data[127 * 5], 0x01);
+}
+
+#[test]
+fn test_get_chunk_uses_instance_pages() {
+    let mut b40 = OledBuffer::new(128, 40);
+    b40.set_pixel(2, 0, true);
+    let chunk = b40.get_chunk(0, 4); // 4 columns × 5 pages
+    assert_eq!(chunk.len(), 20);
+    assert_eq!(chunk[2 * 5], 0x01);
+}
+
+#[test]
+fn test_buffer_clone_is_deep() {
+    let mut a = OledBuffer::new(128, 64);
+    a.set_pixel(1, 1, true);
+    let b = a.clone();
+    assert_eq!(a, b);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml render::tests::test_new_sizes -- --nocapture`
+Expected: COMPILE ERROR (`new` takes 0 args, no `width` field) — that is the failure signal for this step.
+
+- [ ] **Step 3: Rewrite the `OledBuffer` struct and impls**
+
+In `src-tauri/src/render.rs`, replace the struct, `new`, `set_pixel`, `get_chunk`, `DrawTarget`, and `OriginDimensions` (currently around lines 69–131):
+
+```rust
+/// A buffer for a SteelSeries OLED screen. Layout is column-major pages:
+/// for each column, `height/8` bytes; within a byte, bit 0 is the topmost pixel.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OledBuffer {
+    pub width: u32,
+    pub height: u32,
+    pub data: Vec<u8>,
+}
+
+impl OledBuffer {
+    pub fn new(width: u32, height: u32) -> Self {
+        debug_assert!(height % 8 == 0, "OLED height must be a multiple of 8");
+        Self {
+            width,
+            height,
+            data: vec![0u8; (width * height / 8) as usize],
+        }
+    }
+
+    /// Bytes per column (= height / 8).
+    fn pages(&self) -> usize {
+        (self.height / 8) as usize
+    }
+
+    pub fn set_pixel(&mut self, x: u32, y: u32, on: bool) {
+        if x >= self.width || y >= self.height {
+            return;
+        }
+        let pages = self.pages();
+        let idx = x as usize * pages + (y / 8) as usize;
+        let bit = (y % 8) as u8;
+
+        if on {
+            self.data[idx] |= 1 << bit;
+        } else {
+            self.data[idx] &= !(1 << bit);
+        }
+    }
+
+    pub fn get_chunk(&self, x_offset: u8, width: u8) -> Vec<u8> {
+        let pages = self.pages();
+        let mut chunk = Vec::with_capacity(width as usize * pages);
+        for x in x_offset..(x_offset + width) {
+            let start = x as usize * pages;
+            chunk.extend_from_slice(&self.data[start..start + pages]);
+        }
+        chunk
+    }
+}
+
+impl DrawTarget for OledBuffer {
+    type Color = BinaryColor;
+    type Error = core::convert::Infallible;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for Pixel(point, color) in pixels.into_iter() {
+            if point.x >= 0
+                && point.x < self.width as i32
+                && point.y >= 0
+                && point.y < self.height as i32
+            {
+                self.set_pixel(point.x as u32, point.y as u32, color.is_on());
+            }
+        }
+        Ok(())
+    }
+}
+
+impl OriginDimensions for OledBuffer {
+    fn size(&self) -> Size {
+        Size::new(self.width, self.height)
+    }
+}
+```
+
+- [ ] **Step 4: Update every call site (mechanical)**
+
+- `src-tauri/src/render.rs`: `render_text_to_oled` body: `OledBuffer::new()` → `OledBuffer::new(128, 64)` (made dynamic in Task 3). Every test calling `OledBuffer::new()` → `OledBuffer::new(128, 64)`.
+- `src-tauri/src/state.rs:68`: `oled_buffer: OledBuffer::new()` → `OledBuffer::new(128, 64)`.
+- `src-tauri/src/daemon.rs`:
+  - `white_buffer()` (line ~149): `OledBuffer::new()` → `OledBuffer::new(128, 64)` (generalized in Task 5).
+  - `send_blank` (line ~253): `OledBuffer::new()` → `OledBuffer::new(128, 64)`.
+  - Lines ~668 and ~715: `s.oled_buffer = OledBuffer { data: buffer.data }` → `s.oled_buffer = buffer.clone()`.
+  - All test call sites `OledBuffer::new()` → `OledBuffer::new(128, 64)`.
+- `src-tauri/src/gui.rs:1195` (test): `OledBuffer::new()` → `OledBuffer::new(128, 64)`.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: PASS (including the four new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/render.rs src-tauri/src/daemon.rs src-tauri/src/gui.rs src-tauri/src/state.rs
+git commit -m "refactor(render): resolution-aware OledBuffer with runtime dimensions"
+```
+
+---
+
+### Task 2: `to_page_major()` serialization for the Apex protocol
+
+**Files:**
+- Modify: `src-tauri/src/render.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the `tests` module in `src-tauri/src/render.rs`:
+
+```rust
+#[test]
+fn test_to_page_major_length_and_ordering() {
+    let mut b = OledBuffer::new(128, 40);
+    // (0,0) → page 0, column 0, bit 0 → out[0] = 0x01
+    b.set_pixel(0, 0, true);
+    // (5,9) → page 1, column 5, bit 1 → out[1*128 + 5] = 0x02
+    b.set_pixel(5, 9, true);
+    // (127,39) → page 4, column 127, bit 7 → out[4*128 + 127] = 0x80
+    b.set_pixel(127, 39, true);
+
+    let out = b.to_page_major();
+    assert_eq!(out.len(), 640);
+    assert_eq!(out[0], 0x01);
+    assert_eq!(out[128 + 5], 0x02);
+    assert_eq!(out[4 * 128 + 127], 0x80);
+}
+
+#[test]
+fn test_to_page_major_empty_buffer_is_zeroes() {
+    let b = OledBuffer::new(128, 64);
+    let out = b.to_page_major();
+    assert_eq!(out.len(), 1024);
+    assert!(out.iter().all(|&byte| byte == 0));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml render::tests::test_to_page_major`
+Expected: COMPILE ERROR — `to_page_major` not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `impl OledBuffer` in `src-tauri/src/render.rs`:
+
+```rust
+/// Serialize to SSD1306 page-major order: all columns of page 0, then
+/// page 1, etc. (The internal layout is column-major pages.) Used by the
+/// Apex legacy protocol.
+pub fn to_page_major(&self) -> Vec<u8> {
+    let pages = self.pages();
+    let mut out = Vec::with_capacity(self.data.len());
+    for page in 0..pages {
+        for x in 0..self.width as usize {
+            out.push(self.data[x * pages + page]);
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml render::tests::test_to_page_major`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/render.rs
+git commit -m "feat(render): SSD1306 page-major serialization for Apex protocol"
+```
+
+---
+
+### Task 3: `render_text_to_oled` and `load_image_to_buffer` take target dimensions
+
+**Files:**
+- Modify: `src-tauri/src/render.rs`
+- Modify: `src-tauri/src/daemon.rs:105-107` (`value_to_oled_buffer`)
+- Modify: `src-tauri/src/gui.rs:365,398,409` (preview render calls)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the `tests` module in `src-tauri/src/render.rs`:
+
+```rust
+#[test]
+fn test_render_text_at_explicit_dimensions() {
+    let buf = render_text_to_oled("Hi", 0, &[], 128, 40);
+    assert_eq!(buf.width, 128);
+    assert_eq!(buf.height, 40);
+    assert_eq!(buf.data.len(), 640);
+    // Something was drawn
+    assert!(buf.data.iter().any(|&b| b != 0));
+}
+
+#[test]
+fn test_render_clips_safely_on_short_screen() {
+    // 5 lines of Large font massively overflow 40px; must not panic.
+    let buf = render_text_to_oled(
+        "A\nB\nC\nD\nE",
+        0,
+        &[FontSize::Large; 5],
+        128,
+        40,
+    );
+    assert_eq!(buf.data.len(), 640);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml render::tests::test_render_text_at_explicit`
+Expected: COMPILE ERROR — wrong number of arguments.
+
+- [ ] **Step 3: Change signatures**
+
+In `src-tauri/src/render.rs`:
+
+```rust
+pub fn render_text_to_oled(
+    text: &str,
+    x: i32,
+    line_fonts: &[FontSize],
+    width: u32,
+    height: u32,
+) -> OledBuffer {
+    let mut buffer = OledBuffer::new(width, height);
+    // ... body unchanged ...
+}
+```
+
+In `load_image_to_buffer`, replace the hardcoded bounds (lines ~267 and ~271):
+
+```rust
+for y in 0..height {
+    if y + y_off >= buffer.height {
+        break;
+    }
+    for x in 0..width {
+        if x + x_off >= buffer.width {
+            break;
+        }
+        // ... unchanged ...
+    }
+}
+```
+
+(Rename the local image dims if they shadow — the decoded image's `(width, height)` from `gray.dimensions()` stays as-is; only the boundary checks change to `buffer.width` / `buffer.height`.)
+
+- [ ] **Step 4: Update callers (all pass 128×64 for now)**
+
+- `src-tauri/src/render.rs` tests: append `, 128, 64` to every existing `render_text_to_oled(...)` call.
+- `src-tauri/src/daemon.rs:105`:
+
+```rust
+fn value_to_oled_buffer(value: &Value, font_sizes: &[FontSize], size: (u32, u32)) -> OledBuffer {
+    render_text_to_oled(&value_to_text(value), 0, font_sizes, size.0, size.1)
+}
+```
+
+  Both call sites in `tick()` (lines ~663 and ~703) pass `(128, 64)` for now (Task 5 makes this dynamic). Update any tests calling `value_to_oled_buffer`.
+- `src-tauri/src/gui.rs` lines 365, 398, 409: append `, 128, 64` (Task 6 makes these dynamic).
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/render.rs src-tauri/src/daemon.rs src-tauri/src/gui.rs
+git commit -m "refactor(render): render_text_to_oled takes target dimensions"
+```
+
+---
+
+### Task 4: `devices.rs` registry with `Protocol::build_packets`
+
+Create the registry module. Move the packet-building logic out of `daemon.rs` into `Protocol::NovaPro`'s match arm; add the `ApexLegacy` arm. The daemon's three `OledClient::Hid` branches call `Protocol::NovaPro.build_packets(...)` temporarily (hardcoded until Task 5 threads the device through).
+
+**Files:**
+- Create: `src-tauri/src/devices.rs`
+- Modify: `src-tauri/src/main.rs` (add `mod devices;` after `mod consts;`)
+- Modify: `src-tauri/src/daemon.rs` (delete `build_hid_packet` / `build_hid_packets_for_buffer` + their tests; call the protocol)
+
+- [ ] **Step 1: Create `src-tauri/src/devices.rs` with failing tests**
+
+```rust
+use crate::render::OledBuffer;
+
+/// HID packet protocol family for a direct-USB OLED device. Each variant
+/// owns the full frame encoding for its device family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+    /// Arctis Nova Pro (Wireless) base station: two 1024-byte feature
+    /// reports, header [0x06, 0x93, chunk_x, 0, 64, height], column-major
+    /// bitmap in 64-column chunks.
+    NovaPro,
+    /// Apex 5/7/Pro legacy keyboards: one 641-byte feature report,
+    /// 0x61 followed by the 640-byte SSD1306 page-major bitmap.
+    ApexLegacy,
+}
+
+/// One supported direct-USB device model.
+#[derive(Debug)]
+pub struct SupportedDevice {
+    /// Display name shown in the GUI device picker.
+    pub name: &'static str,
+    pub product_ids: &'static [u16],
+    pub width: u32,
+    pub height: u32,
+    pub protocol: Protocol,
+}
+
+/// Registry of devices supported in direct-USB mode. VID is always 0x1038
+/// (enforced by the discovery filter in connect.rs). To add a device that
+/// speaks an existing protocol, add a row. A new packet format needs a new
+/// Protocol variant and a build_packets arm.
+///
+/// PID→model mapping verified against apex-tux (apex-hardware/src/usb.rs).
+/// Apex Gen3 (0x1640/0x1644/0x1646) intentionally absent — different
+/// protocols, not yet implemented.
+pub static SUPPORTED_DEVICES: &[SupportedDevice] = &[
+    SupportedDevice {
+        name: "Arctis Nova Pro Wireless",
+        product_ids: &[0x12E0],
+        width: 128,
+        height: 64,
+        protocol: Protocol::NovaPro,
+    },
+    SupportedDevice {
+        name: "Apex Pro",
+        product_ids: &[0x1610],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+    SupportedDevice {
+        name: "Apex 7",
+        product_ids: &[0x1612],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+    SupportedDevice {
+        name: "Apex Pro TKL",
+        product_ids: &[0x1614],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+    SupportedDevice {
+        name: "Apex 7 TKL",
+        product_ids: &[0x1618],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+    SupportedDevice {
+        name: "Apex 5",
+        product_ids: &[0x161C],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+];
+
+/// Look up the registry entry for a product ID.
+pub fn find_supported(product_id: u16) -> Option<&'static SupportedDevice> {
+    SUPPORTED_DEVICES
+        .iter()
+        .find(|d| d.product_ids.contains(&product_id))
+}
+
+impl Protocol {
+    /// Build the complete HID feature-report sequence for one frame.
+    pub fn build_packets(&self, buf: &OledBuffer) -> Vec<Vec<u8>> {
+        match self {
+            Protocol::NovaPro => [0u8, 64u8]
+                .iter()
+                .map(|&chunk_x| {
+                    let bitmap = buf.get_chunk(chunk_x, 64);
+                    let mut packet =
+                        vec![0x06u8, 0x93, chunk_x, 0, 64, buf.height as u8];
+                    packet.extend_from_slice(&bitmap);
+                    packet.resize(1024, 0);
+                    packet
+                })
+                .collect(),
+            Protocol::ApexLegacy => {
+                let mut packet = Vec::with_capacity(641);
+                packet.push(0x61);
+                packet.extend_from_slice(&buf.to_page_major());
+                vec![packet]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_supported_nova_pro() {
+        let d = find_supported(0x12E0).expect("Nova Pro in registry");
+        assert_eq!(d.name, "Arctis Nova Pro Wireless");
+        assert_eq!((d.width, d.height), (128, 64));
+        assert_eq!(d.protocol, Protocol::NovaPro);
+    }
+
+    #[test]
+    fn test_find_supported_apex_pro() {
+        let d = find_supported(0x1610).expect("Apex Pro in registry");
+        assert_eq!(d.name, "Apex Pro");
+        assert_eq!((d.width, d.height), (128, 40));
+        assert_eq!(d.protocol, Protocol::ApexLegacy);
+    }
+
+    #[test]
+    fn test_find_supported_all_apex_legacy_pids() {
+        for pid in [0x1610u16, 0x1612, 0x1614, 0x1618, 0x161C] {
+            let d = find_supported(pid).unwrap_or_else(|| panic!("PID {pid:#06X} missing"));
+            assert_eq!(d.protocol, Protocol::ApexLegacy);
+            assert_eq!((d.width, d.height), (128, 40));
+        }
+    }
+
+    #[test]
+    fn test_find_supported_unknown_pid_is_none() {
+        assert!(find_supported(0x9999).is_none());
+        // Gen3 PIDs are deliberately unsupported for now
+        assert!(find_supported(0x1640).is_none());
+        assert!(find_supported(0x1644).is_none());
+        assert!(find_supported(0x1646).is_none());
+    }
+
+    #[test]
+    fn test_nova_pro_packets_layout() {
+        let mut buf = OledBuffer::new(128, 64);
+        buf.set_pixel(0, 0, true); // first byte of chunk 0
+        buf.set_pixel(64, 0, true); // first byte of chunk 1
+
+        let packets = Protocol::NovaPro.build_packets(&buf);
+        assert_eq!(packets.len(), 2);
+        for (i, p) in packets.iter().enumerate() {
+            assert_eq!(p.len(), 1024);
+            assert_eq!(p[0], 0x06);
+            assert_eq!(p[1], 0x93);
+            assert_eq!(p[2], if i == 0 { 0 } else { 64 }); // chunk_x
+            assert_eq!(p[3], 0);
+            assert_eq!(p[4], 64); // chunk width
+            assert_eq!(p[5], 64); // screen height
+            assert_eq!(p[6], 0x01); // pixel at top-left of this chunk
+        }
+    }
+
+    #[test]
+    fn test_apex_legacy_packet_layout() {
+        let mut buf = OledBuffer::new(128, 40);
+        buf.set_pixel(0, 0, true); // page 0, col 0 → payload byte 0
+        buf.set_pixel(127, 39, true); // page 4, col 127 → last payload byte
+
+        let packets = Protocol::ApexLegacy.build_packets(&buf);
+        assert_eq!(packets.len(), 1);
+        let p = &packets[0];
+        assert_eq!(p.len(), 641);
+        assert_eq!(p[0], 0x61);
+        assert_eq!(p[1], 0x01); // (0,0)
+        assert_eq!(p[640], 0x80); // (127,39): bit 7 of page 4
+    }
+}
+```
+
+- [ ] **Step 2: Register the module and verify tests fail then pass**
+
+Add `mod devices;` to `src-tauri/src/main.rs` (after `mod consts;` at line 9).
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml devices::`
+Expected: PASS (module is self-contained; if it doesn't compile, fix before proceeding).
+
+- [ ] **Step 3: Delete daemon's packet builders, call the protocol**
+
+In `src-tauri/src/daemon.rs`:
+- Delete `build_hid_packet` (lines ~140–146) and `build_hid_packets_for_buffer` (lines ~159–168).
+- Delete their tests: `test_build_hid_packet_header_layout`, `test_build_hid_packets_for_buffer_produces_two_packets` (covered by `devices::tests` now).
+- Add import: `use crate::devices::Protocol;`
+- Replace the three `build_hid_packets_for_buffer(...)` calls:
+  - `trigger_frame` Hid arm: `for packet in Protocol::NovaPro.build_packets(buffer) {`
+  - `send_blank` Hid arm: `for packet in Protocol::NovaPro.build_packets(&OledBuffer::new(128, 64)) {`
+  - `send_white` Hid arm: `for packet in Protocol::NovaPro.build_packets(&buffer) {`
+
+(Still hardcoded NovaPro — Task 5 threads the real device through.)
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/devices.rs src-tauri/src/main.rs src-tauri/src/daemon.rs
+git commit -m "feat(devices): supported-device registry with per-protocol packet builders"
+```
+
+---
+
+### Task 5: Connect only supported devices; daemon renders at device dimensions
+
+`connect.rs` filters to registry devices and returns the matched entry. `OledClient::Hid` becomes a struct variant carrying it. The daemon stores the active display size and uses it everywhere.
+
+**Files:**
+- Modify: `src-tauri/src/connect.rs`
+- Modify: `src-tauri/src/daemon.rs`
+
+- [ ] **Step 1: Write failing tests in `connect.rs`**
+
+Add to the `tests` module in `src-tauri/src/connect.rs`:
+
+```rust
+#[test]
+fn test_unsupported_devices_error_lists_models() {
+    let msg = unsupported_devices_error(&[
+        ("SteelSeries Something".to_string(), 0x1234u16),
+        ("".to_string(), 0xABCD),
+    ]);
+    assert!(msg.contains("SteelSeries Something (PID 0x1234)"));
+    assert!(msg.contains("unknown device (PID 0xABCD)"));
+    assert!(msg.contains("not yet supported for direct USB"));
+}
+
+#[test]
+fn test_find_hid_device_returns_supported_entry_when_present() {
+    let Some(api) = try_hid_api_for_connect() else {
+        return;
+    };
+    match find_hid_device(&api, "") {
+        Ok((info, supported)) => {
+            // Whatever matched must be a registry device.
+            assert!(supported.product_ids.contains(&info.product_id()));
+        }
+        Err(e) => {
+            // No supported device on this machine — error must be one of
+            // the two known shapes.
+            let s = e.to_string();
+            assert!(
+                s.contains("No SteelSeries OLED") || s.contains("not yet supported"),
+                "unexpected error: {s}"
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml connect::tests::test_unsupported`
+Expected: COMPILE ERROR — `unsupported_devices_error` not found, `find_hid_device` returns a single value.
+
+- [ ] **Step 3: Implement connect.rs changes**
+
+In `src-tauri/src/connect.rs`, add imports and new code:
+
+```rust
+use crate::devices::{find_supported, SupportedDevice};
+
+/// Registry entry for a discovered HID interface, if the device is supported.
+pub fn supported_device(d: &hidapi::DeviceInfo) -> Option<&'static SupportedDevice> {
+    if !is_oled_capable(d) {
+        return None;
+    }
+    find_supported(d.product_id())
+}
+
+/// Error text naming detected-but-unsupported devices. `detected` pairs the
+/// USB product string (may be empty) with the PID.
+pub fn unsupported_devices_error(detected: &[(String, u16)]) -> String {
+    let list = detected
+        .iter()
+        .map(|(name, pid)| {
+            let shown = if name.is_empty() { "unknown device" } else { name };
+            format!("{} (PID 0x{:04X})", shown, pid)
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("Detected {} — not yet supported for direct USB", list)
+}
+```
+
+Rework `find_hid_device` to filter to supported devices and return the entry:
+
+```rust
+/// Finds a supported OLED device matching the optional selector. Empty
+/// selector or no match returns the first supported device. A selector
+/// prefixed with `path:` matches the platform HID device path; otherwise it
+/// is matched as a serial. OLED-capable devices that are not in the
+/// supported-device registry are never returned — if only unsupported
+/// devices are present, the error names them.
+pub fn find_hid_device<'a>(
+    api: &'a HidApi,
+    selector: &str,
+) -> Result<(&'a hidapi::DeviceInfo, &'static SupportedDevice), anyhow::Error> {
+    let oled_capable = list_oled_devices(api);
+    if oled_capable.is_empty() {
+        return Err(anyhow::anyhow!("No SteelSeries OLED device found"));
+    }
+
+    let candidates: Vec<&hidapi::DeviceInfo> = oled_capable
+        .iter()
+        .copied()
+        .filter(|d| supported_device(d).is_some())
+        .collect();
+
+    if candidates.is_empty() {
+        let detected: Vec<(String, u16)> = oled_capable
+            .iter()
+            .map(|d| {
+                (
+                    d.product_string().unwrap_or("").to_string(),
+                    d.product_id(),
+                )
+            })
+            .collect();
+        return Err(anyhow::anyhow!(unsupported_devices_error(&detected)));
+    }
+
+    let with_entry = |d: &'a hidapi::DeviceInfo| {
+        let entry = supported_device(d).expect("candidates are pre-filtered");
+        (d, entry)
+    };
+
+    if let Some(wanted_path) = selector.strip_prefix("path:") {
+        if let Some(d) = candidates
+            .iter()
+            .find(|d| d.path().to_string_lossy() == wanted_path)
+        {
+            return Ok(with_entry(d));
+        }
+        warn!(
+            "Configured device path '{}' not present; falling back to first supported OLED device",
+            wanted_path
+        );
+        return Ok(with_entry(candidates[0]));
+    }
+
+    let serials: Vec<Option<&str>> = candidates.iter().map(|d| d.serial_number()).collect();
+    match pick_oled_index(&serials, selector) {
+        Some(idx) => {
+            if !selector.is_empty() && serials[idx] != Some(selector) {
+                warn!(
+                    "Configured device serial '{}' not present; falling back to first supported OLED device",
+                    selector
+                );
+            }
+            Ok(with_entry(candidates[idx]))
+        }
+        None => Err(anyhow::anyhow!("No SteelSeries OLED device found")),
+    }
+}
+```
+
+Update `connect_hid`:
+
+```rust
+pub fn connect_hid(
+    term: &Term,
+    api: &HidApi,
+    serial: &str,
+) -> Result<(HidDevice, &'static SupportedDevice), anyhow::Error> {
+    retry_connect(term, "SteelSeries OLED (HID)", || {
+        let (device_info, supported) = find_hid_device(api, serial)?;
+
+        let device = device_info.open_device(api).map_err(|e| {
+            error!("Failed to open HID device: {}", e);
+            anyhow::anyhow!("Failed to open HID device: {}", e)
+        })?;
+        Ok((device, supported))
+    })
+}
+```
+
+Fix existing tests that destructure the old return types:
+- `test_connect_functions_exist`: change the `_hid_fn` line to
+  `let _hid_fn: fn(&Term, &HidApi, &str) -> Result<(HidDevice, &'static crate::devices::SupportedDevice), anyhow::Error> = connect_hid;`
+- `test_find_hid_device_path_selector_matches_when_present`: the success arm becomes `let (info, _supported) = r.unwrap(); assert_eq!(info.path().to_string_lossy(), path);` — and the "device present" pre-check must use supported devices: replace `candidates.first()` with a filter via `supported_device`, returning early when none.
+- `test_find_hid_device_no_devices_returns_err`: the present-device assertion becomes `assert!(find_hid_device(&api, "").is_ok() || find_hid_device(&api, "").err().map(|e| e.to_string().contains("not yet supported")).unwrap_or(false));` — simpler: when `list_oled_devices` is non-empty, accept either Ok or the "not yet supported" error.
+
+- [ ] **Step 4: Thread the device through the daemon**
+
+In `src-tauri/src/daemon.rs`:
+
+Change the enum (line ~196):
+
+```rust
+enum OledClient {
+    GameSense(GameSenseClient),
+    Hid {
+        sender: Box<dyn HidSender>,
+        device: &'static crate::devices::SupportedDevice,
+    },
+}
+```
+
+Update the three protocol call sites:
+
+```rust
+// trigger_frame:
+OledClient::Hid { sender, device } => {
+    for packet in device.protocol.build_packets(buffer) {
+        if let Err(e) = sender.send_feature_report(&packet) {
+            error!("Failed to send HID frame: {}", e);
+            return Err(anyhow!("HID send failed: {}", e));
+        }
+    }
+}
+
+// send_blank:
+OledClient::Hid { sender, device } => {
+    let blank = OledBuffer::new(device.width, device.height);
+    for packet in device.protocol.build_packets(&blank) {
+        let _ = sender.send_feature_report(&packet);
+    }
+}
+
+// send_white:
+OledClient::Hid { sender, device } => {
+    let buffer = white_buffer(device.width, device.height);
+    for packet in device.protocol.build_packets(&buffer) {
+        let _ = sender.send_feature_report(&packet);
+    }
+}
+```
+
+Generalize `white_buffer`:
+
+```rust
+/// Pure helper: create an OledBuffer with every pixel turned on ("white" screen).
+fn white_buffer(width: u32, height: u32) -> OledBuffer {
+    let mut buffer = OledBuffer::new(width, height);
+    for x in 0..width {
+        for y in 0..height {
+            buffer.set_pixel(x, y, true);
+        }
+    }
+    buffer
+}
+```
+
+(`send_white`'s GameSense arm doesn't use `white_buffer`; only the Hid arm calls it. Update any `white_buffer()` test call sites to `white_buffer(128, 64)`.)
+
+Add `display_size` to the `Daemon` struct (after `page_counter`):
+
+```rust
+/// Active OLED dimensions: registry entry's size in direct-USB mode,
+/// 128×64 for GameSense.
+display_size: (u32, u32),
+```
+
+Initialize in `Daemon::new`: `display_size: (128, 64),`
+
+In `connect_all` (line ~532):
+
+```rust
+if self.config.direct_usb {
+    self.announce_connecting_direct_usb();
+
+    let api = hidapi::HidApi::new().map_err(|e| anyhow!("HID API init failed: {}", e))?;
+    let (device, supported) = connect_hid(&self.term, &api, &self.config.direct_usb_serial)?;
+    info!(
+        "Direct USB device: {} ({}x{})",
+        supported.name, supported.width, supported.height
+    );
+    self.display_size = (supported.width, supported.height);
+    self.oled = Some(Box::new(OledClient::Hid {
+        sender: Box::new(device),
+        device: supported,
+    }));
+    self.hid_api = Some(api);
+
+    self.after_direct_usb_connected();
+} else {
+    self.display_size = (128, 64);
+    // ... GameSense branch unchanged ...
+```
+
+In `tick()`, pass the size to both render calls (lines ~663 and ~703):
+
+```rust
+let buffer = value_to_oled_buffer(&value, &self.config.font_sizes, self.display_size);
+```
+
+Update daemon tests: every `OledClient::Hid(Box::new(...))` becomes
+
+```rust
+fn nova_device() -> &'static crate::devices::SupportedDevice {
+    crate::devices::find_supported(0x12E0).expect("Nova Pro in registry")
+}
+
+// then:
+let mut oled = OledClient::Hid {
+    sender: Box::new(FakeHidSender::new()),
+    device: nova_device(),
+};
+```
+
+Add one new daemon test exercising the Apex path through the mock sender:
+
+```rust
+#[test]
+fn test_oled_client_hid_apex_sends_single_641_byte_packet() {
+    let fake = FakeHidSender::new();
+    let calls = fake.calls.clone();
+    let mut oled = OledClient::Hid {
+        sender: Box::new(fake),
+        device: crate::devices::find_supported(0x1610).expect("Apex Pro in registry"),
+    };
+    let buf = OledBuffer::new(128, 40);
+    let value = json!({"line1": "x"});
+    oled.trigger_frame("PAGE1", 0, &value, &buf).unwrap();
+
+    let sent = calls.lock().unwrap();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].len(), 641);
+    assert_eq!(sent[0][0], 0x61);
+}
+```
+
+(Adapt to `FakeHidSender`'s actual construction — it already records packets in `self.calls`; if `calls` is not clonable/shared, follow the pattern of the existing `test_oled_client_hid_trigger_frame_sends_two_packets` test.)
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/connect.rs src-tauri/src/daemon.rs
+git commit -m "feat(connect,daemon): registry-gated direct-USB connect with per-device protocol dispatch"
+```
+
+---
+
+### Task 6: Dimensions in shared state, frame payloads, and device listing
+
+**Files:**
+- Modify: `src-tauri/src/state.rs` (display size + `OledFrame` payload struct)
+- Modify: `src-tauri/src/daemon.rs` (`push_frame`, write display size to state, `buffer_to_rgba_grayscale`)
+- Modify: `src-tauri/src/gui.rs` (`buffer_to_pixels` → dims-aware; preview commands return `OledFrame`; `HidDeviceInfo` gains supported fields)
+
+- [ ] **Step 1: Write failing tests**
+
+In `src-tauri/src/state.rs` tests:
+
+```rust
+#[test]
+fn test_new_initializes_display_size() {
+    let state = SharedState::new(mock_config());
+    assert_eq!(state.display_size, (128, 64));
+}
+
+#[test]
+fn test_oled_frame_serializes() {
+    let f = OledFrame {
+        width: 128,
+        height: 40,
+        pixels: vec![0; 3],
+    };
+    let s = serde_json::to_string(&f).unwrap();
+    assert!(s.contains("\"width\":128"));
+    assert!(s.contains("\"height\":40"));
+    assert!(s.contains("\"pixels\""));
+}
+```
+
+In `src-tauri/src/gui.rs` tests (adapting the existing `test_buffer_to_pixels_size_and_mapping`):
+
+```rust
+#[test]
+fn test_buffer_to_pixels_uses_buffer_dimensions() {
+    let mut buf = OledBuffer::new(128, 40);
+    buf.set_pixel(0, 0, true);
+    let frame = buffer_to_frame(&buf);
+    assert_eq!(frame.width, 128);
+    assert_eq!(frame.height, 40);
+    assert_eq!(frame.pixels.len(), 128 * 40);
+    assert_eq!(frame.pixels[0], 255);
+    assert_eq!(frame.pixels[1], 0);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml state::tests::test_new_initializes_display_size`
+Expected: COMPILE ERROR — no `display_size` field, no `OledFrame`.
+
+- [ ] **Step 3: Implement state.rs**
+
+```rust
+/// One rendered OLED frame for the GUI: grayscale pixel bytes (0 or 255),
+/// row-major, length = width * height.
+#[derive(Debug, Clone, Serialize)]
+pub struct OledFrame {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+```
+
+Add to `SharedState`: `pub display_size: (u32, u32),` — initialize `display_size: (128, 64),` in `new()`.
+
+- [ ] **Step 4: Implement daemon.rs payload changes**
+
+- `buffer_to_rgba_grayscale(buf)` → rename/replace with a dims-aware version emitting `OledFrame` (keep it in daemon.rs):
+
+```rust
+fn buffer_to_frame_payload(buf: &OledBuffer) -> crate::state::OledFrame {
+    let mut pixels = Vec::with_capacity((buf.width * buf.height) as usize);
+    let pages = (buf.height / 8) as usize;
+    for y in 0..buf.height {
+        for x in 0..buf.width {
+            let idx = x as usize * pages + (y / 8) as usize;
+            let on = (buf.data[idx] & (1 << (y % 8))) != 0;
+            pixels.push(if on { 255 } else { 0 });
+        }
+    }
+    crate::state::OledFrame {
+        width: buf.width,
+        height: buf.height,
+        pixels,
+    }
+}
+
+fn push_frame(&self, buf: &OledBuffer) {
+    let _ = self.app.emit("frame", buffer_to_frame_payload(buf));
+}
+```
+
+- In `connect_all`, after setting `self.display_size`, also publish it (both branches — add to `after_direct_usb_connected`/`after_gamesense_connected` is wrong since they don't know the size; instead write it inline in `connect_all` right after each `self.display_size = ...` assignment):
+
+```rust
+let size = self.display_size;
+self.write_state(|s| s.display_size = size);
+```
+
+- Update any tests referencing `buffer_to_rgba_grayscale`.
+
+- [ ] **Step 5: Implement gui.rs changes**
+
+Replace `buffer_to_pixels` with:
+
+```rust
+fn buffer_to_frame(buf: &crate::render::OledBuffer) -> crate::state::OledFrame {
+    let mut pixels = Vec::with_capacity((buf.width * buf.height) as usize);
+    let pages = (buf.height / 8) as usize;
+    for y in 0..buf.height {
+        for x in 0..buf.width {
+            let idx = x as usize * pages + (y / 8) as usize;
+            let on = (buf.data[idx] & (1 << (y % 8))) != 0;
+            pixels.push(if on { 255 } else { 0 });
+        }
+    }
+    crate::state::OledFrame {
+        width: buf.width,
+        height: buf.height,
+        pixels,
+    }
+}
+```
+
+(Duplication with daemon's `buffer_to_frame_payload` — DRY: put ONE copy in `gui.rs` as `pub(crate) fn buffer_to_frame` and have daemon call `crate::gui::buffer_to_frame`. Delete the daemon copy.)
+
+- `get_live_preview` / `preview_config` return `Result<crate::state::OledFrame, String>`; their `_impl` functions render at the live size:
+
+```rust
+fn get_live_preview_impl(shared: &Shared) -> Result<crate::state::OledFrame, String> {
+    let g = shared.lock().map_err(|e| e.to_string())?;
+    Ok(buffer_to_frame(&g.oled_buffer))
+}
+```
+
+In `preview_config_impl`, read the size once at the top — `let (w, h) = { ...lock... g.display_size };` (fold into the existing lock that grabs `hwinfo_snapshot`) — and pass `w, h` to all three `render_text_to_oled` calls; return `buffer_to_frame(&buf)`.
+
+- Extend `HidDeviceInfo`:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct HidDeviceInfo {
+    pub serial: String,
+    pub product: String,
+    pub manufacturer: String,
+    pub vendor_id: u16,
+    pub product_id: u16,
+    pub interface_number: i32,
+    pub path: String,
+    /// True when the device is in the direct-USB supported-device registry.
+    pub supported: bool,
+    /// Registry display name when supported, empty otherwise.
+    pub device_name: String,
+    /// Screen size when supported, 0 otherwise.
+    pub width: u32,
+    pub height: u32,
+}
+```
+
+In `list_hid_devices`, map via the registry:
+
+```rust
+.map(|d| {
+    let entry = crate::connect::supported_device(d);
+    HidDeviceInfo {
+        serial: d.serial_number().unwrap_or("").to_string(),
+        product: d.product_string().unwrap_or("").to_string(),
+        manufacturer: d.manufacturer_string().unwrap_or("").to_string(),
+        vendor_id: d.vendor_id(),
+        product_id: d.product_id(),
+        interface_number: d.interface_number(),
+        path: d.path().to_string_lossy().into_owned(),
+        supported: entry.is_some(),
+        device_name: entry.map(|e| e.name.to_string()).unwrap_or_default(),
+        width: entry.map(|e| e.width).unwrap_or(0),
+        height: entry.map(|e| e.height).unwrap_or(0),
+    }
+})
+```
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/state.rs src-tauri/src/daemon.rs src-tauri/src/gui.rs
+git commit -m "feat(gui,state): dimension-aware frame payloads and supported-device listing"
+```
+
+---
+
+### Task 7: Frontend — adaptive canvas and unsupported-device labelling
+
+**Files:**
+- Modify: `src-tauri/ui/index.html`
+
+- [ ] **Step 1: Make `renderFrame` consume `{width, height, pixels}`**
+
+Replace the existing `renderFrame` (line ~464):
+
+```javascript
+function renderFrame(frame) {
+    if (!frame || !frame.pixels || frame.pixels.length !== frame.width * frame.height) return;
+    if (previewCanvas.width !== frame.width) previewCanvas.width = frame.width;
+    if (previewCanvas.height !== frame.height) previewCanvas.height = frame.height;
+    document.getElementById('preview-caption').textContent =
+        `What is currently on the OLED (${frame.width}×${frame.height})`;
+    const imgData = previewCtx.createImageData(frame.width, frame.height);
+    for (let i = 0; i < frame.pixels.length; i++) {
+        const v = frame.pixels[i];
+        imgData.data[i * 4] = v;
+        imgData.data[i * 4 + 1] = v;
+        imgData.data[i * 4 + 2] = v;
+        imgData.data[i * 4 + 3] = 255;
+    }
+    previewCtx.putImageData(imgData, 0, 0);
+}
+```
+
+All three call sites (`listen('frame', ...)`, `get_live_preview`, `preview_config`) already pass the payload straight through — no changes needed there since the payload shape changed on the backend.
+
+- [ ] **Step 2: Let the canvas keep aspect ratio**
+
+Find the CSS rule sizing the preview canvas (currently `width: 384px; height: 192px;` around lines 129–130) and change the fixed height to auto so a 128×40 frame displays at 384×120:
+
+```css
+width: 384px;
+height: auto;
+```
+
+- [ ] **Step 3: Grey out unsupported devices in the picker**
+
+In `refreshDeviceList` (line ~973), inside the `for (const d of devices)` loop, prefer the registry name and disable unsupported entries. Replace the `const label = ...` line and add the disabled handling after `tail` is computed:
+
+```javascript
+const label = (d.supported && d.device_name)
+    ? d.device_name
+    : (d.product || `Unknown device ${d.product_id.toString(16)}`);
+```
+
+and after `opt.textContent = label + tail;` (or however the existing code joins them — keep its structure):
+
+```javascript
+if (!d.supported) {
+    opt.disabled = true;
+    opt.textContent += ' — not yet supported';
+}
+```
+
+- [ ] **Step 4: Manual smoke check**
+
+Run: `cargo build --manifest-path src-tauri/Cargo.toml` (compile only — UI is static HTML, no bundler).
+Expected: builds clean. Visual verification happens on hardware at the end.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/ui/index.html
+git commit -m "feat(ui): adaptive preview canvas and unsupported-device labels"
+```
+
+---
+
+### Task 8: Final verification
+
+**Files:** none new.
+
+- [ ] **Step 1: Format and lint**
+
+Run: `cargo fmt --manifest-path src-tauri/Cargo.toml`
+Run: `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
+Expected: clean. Fix anything clippy raises; do not `#[allow]` without reason.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: PASS — note total test count vs. main (`git stash`-free comparison not needed; just confirm no test was deleted except the two moved daemon packet tests).
+
+- [ ] **Step 3: On-hardware sanity (user has Nova Pro connected)**
+
+Run: `cargo run --manifest-path src-tauri/Cargo.toml` with `direct_usb=true` in `conf.ini`.
+Expected: log line `Direct USB device: Arctis Nova Pro Wireless (128x64)`; OLED renders as before; GUI live preview shows 128×64 caption.
+
+- [ ] **Step 4: Commit any stragglers and report**
+
+```bash
+git status
+git add -A && git commit -m "chore: fmt/clippy cleanup for device registry"
+```
+
+Only commit if fmt/clippy changed files.
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §1–§7 all map to Tasks 4, 1–3, 5, 5, 6–7, 5–6, 1–6 respectively; the wizard line in spec §5 is a planning-time no-op (wizard never listed devices) — documented in the header notes.
+- Type threads checked: `find_hid_device → (DeviceInfo, &'static SupportedDevice)` → `connect_hid → (HidDevice, &'static SupportedDevice)` → `OledClient::Hid { sender, device }` → `device.protocol.build_packets(&OledBuffer)`; `OledFrame` is the single payload type for live frames and previews; `buffer_to_frame` lives in `gui.rs` only.
+- `FakeHidSender` construction in the new Apex test must follow the existing fixture's API — flagged inline in Task 5 Step 4.

--- a/docs/superpowers/specs/2026-05-29-conditional-pages-design.md
+++ b/docs/superpowers/specs/2026-05-29-conditional-pages-design.md
@@ -1,0 +1,125 @@
+# Conditional Pages (Process-Gated) — Design
+
+**Date:** 2026-05-29
+**Status:** Approved for planning
+
+## Problem
+
+Custom mode rotates through all configured pages on a fixed timer. Users want
+pages that appear only in a relevant context — e.g. a page showing FPS that
+joins the rotation only while a game is running.
+
+## Solution Overview
+
+Each custom page gets an optional **process condition**: one or more exe names.
+The page joins the normal rotation only while a matching process is running.
+Pages with no condition behave exactly as today (always shown).
+
+Decisions made during brainstorming:
+
+- **Behavior:** Join rotation. A matched conditional page is one more page in
+  the normal cycle; an unmatched one is skipped. No takeover, no priority.
+- **Trigger:** Process running (anywhere on the system), not foreground focus.
+- **Config surface:** `conf.ini` **and** the settings GUI.
+- **Empty fallback:** If zero pages qualify (all conditional, none running),
+  ignore conditions and rotate through every page so the screen never goes
+  blank.
+
+This feature controls **page visibility only**. The FPS value itself comes from
+whatever framerate sensor the user places on the page (an HWiNFO/RTSS-fed
+sensor). No new sensor type is added.
+
+## Config Format
+
+New key per `PAGE{i}.Sensors` section:
+
+```ini
+[PAGE2.Sensors]
+show_when_running = game.exe
+sensor_0 = GPU [#0]: ...;Framerate
+```
+
+- Empty or absent → unconditional page (always shown).
+- Match is **case-insensitive exact** on the exe filename (`game.exe`).
+- Comma-separated list allowed; page is active if **any** token matches:
+  `show_when_running = game.exe, launcher.exe`
+
+## Components
+
+### New module: `src-tauri/src/process_watch.rs`
+
+Separates Windows I/O from pure logic for testability.
+
+**`ProcessWatcher`** (stateful, lives in `Daemon` alongside the other readers):
+- Caches a `HashSet<String>` of lowercased running exe filenames.
+- Refreshes via `CreateToolhelp32Snapshot` + `Process32FirstW`/`Process32NextW`
+  at most every ~2 seconds (refresh keyed off the daemon tick counter, since
+  `TICK_RATE` is 500 ms → refresh every ~4 ticks). Enumeration itself is thin
+  and untested, matching the convention of the other Windows-backed readers.
+- `running(&self) -> &HashSet<String>` returns the current cache.
+
+**Pure helpers** (no Windows; fully unit-tested):
+- `parse_condition(raw: &str) -> Vec<String>` — split on commas, trim,
+  lowercase, drop empty tokens.
+- `page_is_active(condition: &str, running: &HashSet<String>) -> bool` — empty
+  condition → `true`; otherwise `true` if any parsed token is in `running`.
+- `active_pages(conditions: &[String], running: &HashSet<String>) -> Vec<usize>`
+  — indices of active pages. **If the result is empty, return all indices**
+  (the fallback).
+
+### `AppConfig` (`settings.rs`)
+
+- Add `page_conditions: Vec<String>`, parallel to `custom_sensors` (index =
+  page number). `#[serde(default)]` so existing serialized configs/state load
+  cleanly.
+- `from_ini`: read `show_when_running` from each `PAGE{i}.Sensors` section into
+  `page_conditions[i-1]` (empty string when absent).
+
+### Daemon rotation (`daemon.rs`)
+
+- Each tick, compute `active = active_pages(&config.page_conditions,
+  watcher.running())`.
+- Rotation cycles over `active` instead of the raw `0..pages` range.
+  `page_counter` is treated as a position within `active`; resolve the real
+  page index as `active[page_counter % active.len()]`.
+- Clamp `page_counter` when `active` shrinks (e.g. the game closes mid-cycle) so
+  it never indexes past the end.
+- `next_page_counter` reworked to advance within `active.len()` on the same
+  timer interval as today (`page_time` × ticks-per-second).
+
+### GUI (`gui.rs` + `ui/index.html`)
+
+- `gui.rs::apply_pages_sections`: write `show_when_running` per page from
+  `page_conditions`.
+- `gui.rs` config round-trip carries `page_conditions` through save/load.
+- `index.html`: one text input per page tab — *"Show only while running
+  (exe):"* — bound to `config.page_conditions[activePage]`, persisted with the
+  rest of the page config.
+
+## Testing
+
+Pure-function unit tests:
+- `parse_condition`: trimming, lowercasing, comma splitting, empty-token drop.
+- `page_is_active`: empty → true; single match; no match; case-insensitivity.
+- `active_pages`: mixed conditional/unconditional; all-unconditional;
+  fallback-to-all when nothing matches.
+- `next_page_counter` rework: advancing within a shrunk active set; clamp on
+  shrink.
+
+Round-trip tests:
+- `show_when_running` survives `ini → AppConfig → ini` via `settings.rs` and
+  `gui.rs`, including the empty/absent case.
+
+Untested (by convention, like the other readers):
+- The raw toolhelp process enumeration in `ProcessWatcher`.
+
+## Out of Scope
+
+- A built-in FPS/RTSS sensor type. FPS comes from a user-selected sensor.
+- Foreground-window detection (chosen trigger is process-running).
+- Per-page priority or takeover behavior.
+
+## Dependencies
+
+No new crates. Process enumeration uses `winapi`/toolhelp already present in the
+tree.

--- a/docs/superpowers/specs/2026-06-11-usb-device-registry-design.md
+++ b/docs/superpowers/specs/2026-06-11-usb-device-registry-design.md
@@ -41,9 +41,12 @@ Source: [apex-tux](https://github.com/not-jan/apex-tux)
 | PIDs | `0x12E0` | `0x1610`, `0x1612`, `0x1614`, `0x1618`, `0x161C` |
 | Screen | 128×64 | 128×40 |
 | Transport | `send_feature_report` | `send_feature_report` |
-| Packets | 2 × 1024 bytes | 1 × 641 bytes |
+| Packets | 2 × 1024 bytes | 1 × 642 bytes |
 | Header | `[0x06, 0x93, chunk_x, 0, 64, 64]` | `[0x61]` |
-| Bitmap | column-major pages (8 vertical px/byte, bit 0 top), 64-column chunks | SSD1306 page-major: 5 pages × 128 bytes = 640 bytes |
+| Bitmap | column-major pages (8 vertical px/byte, bit 0 top), 64-column chunks | row-major MSB-first (16 bytes/row × 40 rows = 640 bytes), then one trailing zero pad byte |
+
+Page-major preceded by `0x61` (642 bytes) is the Apex Gen3 (`0x1640`) format,
+kept in `OledBuffer::to_page_major()` for future use.
 
 Both transports use feature reports, so the existing `HidSender` trait is
 unchanged. Exact Apex model-name↔PID mapping is confirmed against apex-tux
@@ -60,7 +63,8 @@ pub enum Protocol {
     /// Two 1024-byte feature reports, header [0x06, 0x93, x, 0, w, h],
     /// column-major bitmap, 64-column chunks.
     NovaPro,
-    /// One 641-byte feature report: 0x61 + 640-byte page-major bitmap.
+    /// One 642-byte feature report: 0x61 + 640-byte row-major MSB-first
+    /// bitmap + trailing zero pad byte.
     ApexLegacy,
 }
 
@@ -89,7 +93,8 @@ impl Protocol {
 
 `build_hid_packet` and `build_hid_packets_for_buffer` move here from
 `daemon.rs` (NovaPro arm). The ApexLegacy arm is `0x61` followed by the
-640-byte `buf.to_page_major()` bitmap — 641 bytes exactly, no padding.
+640-byte `buf.to_row_major_msb()` bitmap and a trailing zero pad byte —
+642 bytes exactly (apex-tux `FB_SIZE = 40 * 128 / 8 + 2`).
 
 Adding a device that uses an existing protocol = one table row. A new packet
 format = one enum variant + one `build_packets` match arm.
@@ -159,8 +164,8 @@ format = one enum variant + one `build_packets` match arm.
 
 - `devices.rs`: PID lookup hit/miss; golden packet tests per protocol —
   NovaPro: 2 packets, 1024 bytes, header layout, chunk x = 0/64;
-  ApexLegacy: 1 packet, 641 bytes, `0x61` prefix, payload matches
-  `to_page_major`.
+  ApexLegacy: 1 packet, 642 bytes, `0x61` prefix, payload matches
+  `to_row_major_msb` plus a trailing zero pad byte.
 - `render.rs`: `new(w, h)` sizing; `set_pixel` bounds at both 128×64 and
   128×40; `to_page_major` ordering against hand-computed pixels; clipping on
   40-px-tall buffer.

--- a/docs/superpowers/specs/2026-06-11-usb-device-registry-design.md
+++ b/docs/superpowers/specs/2026-06-11-usb-device-registry-design.md
@@ -1,0 +1,178 @@
+# Direct-USB Supported-Device Registry — Design
+
+**Date:** 2026-06-11
+**Status:** Approved pending user review
+
+## Problem
+
+Direct-USB (HID) mode currently hardcodes one packet format — the Arctis Nova
+Pro Wireless protocol — in `daemon.rs`, while device discovery in `connect.rs`
+accepts *any* SteelSeries device (VID `0x1038`) exposing usage page `0xFFC0`.
+Different SteelSeries OLED devices require different HID packets and have
+different screen sizes, so connecting an unlisted device today would send it
+wrong packets. New devices must be addable incrementally.
+
+## Goals
+
+1. A static registry of supported direct-USB devices, each with its PID(s),
+   screen dimensions, and packet protocol.
+2. Devices not in the registry are detected and shown in the GUI as
+   "not yet supported" but cannot be connected in direct-USB mode.
+3. Full resolution generalization now: render pipeline, previews, and GUI
+   handle per-device screen sizes (128×64 and 128×40 initially).
+4. First two registry families: Arctis Nova Pro Wireless and the legacy
+   Apex OLED keyboards.
+
+## Non-Goals
+
+- Apex Gen3 protocols (PIDs `0x1640`, `0x1644`, `0x1646`; 642-byte and
+  chunked variants) — future registry rows/variants.
+- Font auto-scaling for short screens. Existing pixel clipping is safe;
+  Large font on 128×40 simply clips.
+- Config-driven or plugin packet formats. Registry is a compile-time table.
+
+## Verified protocol facts
+
+Source: [apex-tux](https://github.com/not-jan/apex-tux)
+(`apex-hardware/src/usb.rs`) and current working code in this repo.
+
+| | Arctis Nova Pro Wireless | Apex legacy (5/7/Pro, TKL) |
+|---|---|---|
+| PIDs | `0x12E0` | `0x1610`, `0x1612`, `0x1614`, `0x1618`, `0x161C` |
+| Screen | 128×64 | 128×40 |
+| Transport | `send_feature_report` | `send_feature_report` |
+| Packets | 2 × 1024 bytes | 1 × 641 bytes |
+| Header | `[0x06, 0x93, chunk_x, 0, 64, 64]` | `[0x61]` |
+| Bitmap | column-major pages (8 vertical px/byte, bit 0 top), 64-column chunks | SSD1306 page-major: 5 pages × 128 bytes = 640 bytes |
+
+Both transports use feature reports, so the existing `HidSender` trait is
+unchanged. Exact Apex model-name↔PID mapping is confirmed against apex-tux
+constants during implementation; on-hardware verification happens when the
+user's Apex keyboard is connected.
+
+## Design
+
+### 1. New module `src-tauri/src/devices.rs`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+    /// Two 1024-byte feature reports, header [0x06, 0x93, x, 0, w, h],
+    /// column-major bitmap, 64-column chunks.
+    NovaPro,
+    /// One 641-byte feature report: 0x61 + 640-byte page-major bitmap.
+    ApexLegacy,
+}
+
+#[derive(Debug)]
+pub struct SupportedDevice {
+    pub name: &'static str,          // shown in GUI picker
+    pub product_ids: &'static [u16],
+    pub width: u32,
+    pub height: u32,
+    pub protocol: Protocol,
+}
+
+pub static SUPPORTED_DEVICES: &[SupportedDevice] = &[
+    // Arctis Nova Pro Wireless — 128×64, NovaPro
+    // Apex legacy models — 128×40, ApexLegacy (one row per model name)
+];
+
+/// PID lookup. VID is always 0x1038 (enforced upstream by discovery filter).
+pub fn find_supported(product_id: u16) -> Option<&'static SupportedDevice>;
+
+impl Protocol {
+    /// Build the full HID packet sequence for one frame.
+    pub fn build_packets(&self, buf: &OledBuffer) -> Vec<Vec<u8>>;
+}
+```
+
+`build_hid_packet` and `build_hid_packets_for_buffer` move here from
+`daemon.rs` (NovaPro arm). The ApexLegacy arm is `0x61` followed by the
+640-byte `buf.to_page_major()` bitmap — 641 bytes exactly, no padding.
+
+Adding a device that uses an existing protocol = one table row. A new packet
+format = one enum variant + one `build_packets` match arm.
+
+### 2. Resolution-aware `OledBuffer` (`render.rs`)
+
+- Fields become `{ width: u32, height: u32, data: Vec<u8> }` with
+  `data.len() == width * height / 8`; constructor `OledBuffer::new(width, height)`.
+  Heights are multiples of 8 for all targets (64, 40).
+- Derive `Clone`; replaces manual `OledBuffer { data: buffer.data }` copies.
+- `set_pixel`, `DrawTarget::draw_iter`, `OriginDimensions::size`, `get_chunk`,
+  and `load_image_to_buffer` use instance dims instead of 128/64 literals.
+- New `to_page_major(&self) -> Vec<u8>`: SSD1306 ordering (page 0 across all
+  columns, then page 1, …) for the Apex protocol.
+- `render_text_to_oled(text, x, line_fonts)` gains target dimensions
+  (signature: `render_text_to_oled(text, x, line_fonts, width, height)`).
+  Line layout logic is unchanged; clipping handles overflow on short screens.
+
+### 3. Discovery vs. connection (`connect.rs`)
+
+- `is_oled_capable` (VID + usage page filter) is unchanged — discovery still
+  lists every SteelSeries OLED-class interface so the GUI can show them.
+- `find_hid_device` narrows candidates to registry-supported devices before
+  applying the serial/`path:` selector. If OLED-capable devices exist but none
+  is supported, the error names them:
+  `"Detected <product> (PID 0xXXXX) — not yet supported for direct USB"`.
+- `connect_hid` returns `(HidDevice, &'static SupportedDevice)` so the daemon
+  knows dimensions and protocol. Retry behavior unchanged.
+
+### 4. Daemon dispatch (`daemon.rs`)
+
+- `OledClient::Hid` becomes a struct variant:
+  `Hid { sender: Box<dyn HidSender>, device: &'static SupportedDevice }`.
+- `trigger_frame`, `send_blank`, `send_white` call
+  `device.protocol.build_packets(buffer)`; blank/white buffers are created at
+  device dimensions (`OledBuffer::new(w, h)` / generalized `white_buffer(w, h)`).
+- The daemon stores the active display dimensions and renders every frame at
+  them. GameSense mode fixes them at 128×64.
+- On HID connect, the daemon writes the active dims into shared state.
+
+### 5. GUI and previews (`gui.rs`, `state.rs`, `ui/index.html`)
+
+- `HidDeviceInfo` gains `supported: bool`, `device_name: String` (registry
+  name, falling back to USB product string), `width: u32`, `height: u32`.
+- Device picker: unsupported devices render greyed out with a
+  "not yet supported" label and are unselectable.
+- `SharedState` gains display dims (default 128×64; daemon updates on
+  connect). `oled_buffer` initializes at those dims.
+- Frame/preview payloads change from bare `Vec<u8>` to
+  `{ width, height, pixels }` (`push_frame` event, `get_live_preview`,
+  `preview_config`). `buffer_to_pixels` / `buffer_to_rgba_grayscale` iterate
+  instance dims.
+- `index.html`: canvas `width`/`height` and the caption text are set from the
+  payload instead of hardcoded 128×64; the preview keeps its 3× CSS scale.
+- `settings.rs` console wizard: the direct-USB device list shows supported
+  devices only.
+
+### 6. Error handling
+
+- Wrong-packets-to-wrong-device is impossible by construction: the protocol is
+  derived from the PID via the registry, never assumed.
+- Unsupported-device connect attempts fail fast with a named, actionable error
+  (device shows up in GUI with explanation rather than silently missing).
+- All existing retry/disconnect behavior is unchanged.
+
+### 7. Testing
+
+- `devices.rs`: PID lookup hit/miss; golden packet tests per protocol —
+  NovaPro: 2 packets, 1024 bytes, header layout, chunk x = 0/64;
+  ApexLegacy: 1 packet, 641 bytes, `0x61` prefix, payload matches
+  `to_page_major`.
+- `render.rs`: `new(w, h)` sizing; `set_pixel` bounds at both 128×64 and
+  128×40; `to_page_major` ordering against hand-computed pixels; clipping on
+  40-px-tall buffer.
+- `connect.rs`: supported-filter selection; unsupported-only error message.
+- `gui.rs`: `HidDeviceInfo.supported` flag mapping; payload dims.
+- All existing tests updated for the `OledBuffer::new(w, h)` signature
+  (mechanical; tests pin 128×64 unless exercising 128×40).
+
+## Migration notes
+
+- `conf.ini` is unchanged — `direct_usb_serial` keeps its meaning; selection
+  simply applies after the supported-filter.
+- Behavior change: a non-registry SteelSeries OLED device that previously
+  connected (and received NovaPro packets) now refuses with a clear error.
+  This is intentional.

--- a/docs/superpowers/specs/2026-06-30-screensaver-mode-design.md
+++ b/docs/superpowers/specs/2026-06-30-screensaver-mode-design.md
@@ -1,0 +1,229 @@
+# Screensaver mode — design
+
+- **Date:** 2026-06-30
+- **Status:** Approved (pending spec review)
+- **Branch:** feat/usb-device-registry (or a new feat/screensaver branch)
+
+## Summary
+
+Add an idle-triggered **screensaver** to the OLED display whose purpose is **OLED
+burn-in prevention**. The normal sensor display runs as today; after the PC has
+had no keyboard/mouse input for N minutes, the screen switches to a **bouncing
+clock** (12-hour `H:MM`, DVD-logo style motion). Any keyboard/mouse activity
+returns it to the normal sensor display.
+
+The animation is rendered with full pixel control on the **direct-USB** path. In
+**GameSense** mode — where we can only hand SteelSeries three lines of text and
+cannot position pixels — the idle state falls back to the existing **blank Sleep**
+(burn-in is still prevented; there is just no animation).
+
+## Goals
+
+- Prevent burn-in by ensuring lit pixels move when the machine is idle.
+- Keep the idle display glanceable (you can read the time across the room).
+- Zero behavior change for existing users until they opt in.
+- Small, isolated, independently testable units; no Windows calls in the testable core.
+
+## Non-goals
+
+- Smooth high-frame-rate animation (the daemon ticks at 500 ms; a slow drift is fine).
+- GameSense pixel-positioned animation (constrained by SteelSeries' renderer).
+- Detecting "idle" by sensor staleness (we use real system input idle).
+- A general animation framework / multiple screensaver styles (one: bouncing clock).
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Purpose | Burn-in prevention |
+| Trigger | Idle-triggered: PC idle N min → animation; activity → back to sensors |
+| Content | Bouncing clock (DVD-logo bounce) |
+| Output scope | Direct-USB animates; GameSense falls back to blank Sleep when idle |
+| Default timeout | 5 minutes (GUI seeds this when enabled) |
+| Default state | OFF — `screensaver_idle_minutes` defaults to `0` (disabled) |
+| Clock format | 12-hour, no am/pm, e.g. `3:42` |
+| GUI | Include the settings control now |
+
+## Behavior
+
+1. Each daemon tick (500 ms), after the existing reload/sleep handling and the
+   `is_sleeping`/`is_white_screen` early-return (so **manual Sleep/White always
+   wins**), the daemon reads the system-wide idle time.
+2. `should_screensave = config.screensaver_idle_minutes > 0
+   && idle_ms >= screensaver_idle_minutes * 60_000`.
+3. If `should_screensave`:
+   - **Direct-USB:** advance the bounce, render the clock into an `OledBuffer` at
+     `(x, y)`, send the frame, push frame + status to the GUI, set
+     `screensaver_active = true`, advance `i`, and return early (skip the sensor
+     build and HWiNFO disconnect check for this tick).
+   - **GameSense:** if not already in screensaver, send blank once (reuse
+     `OledClient::send_blank`); set `screensaver_active = true`; return early.
+     Subsequent idle ticks do nothing (no re-blank spamming).
+4. If not idle and `screensaver_active` was set, clear it (wake): the normal
+   sensor render resumes on this tick (direct-USB) / next frame (GameSense).
+
+Notes:
+- While the screensaver is active, HWiNFO disconnect detection is paused (the user
+  is away; this is acceptable and keeps the path simple).
+- Manual Sleep/White, set via tray or GUI, short-circuit before the screensaver
+  logic, so they continue to take precedence.
+
+## Components
+
+Each unit has one purpose, a clear interface, and is testable in isolation.
+
+### 1. `src-tauri/src/idle.rs` (new) — system idle detection
+
+```rust
+/// Milliseconds since the last system-wide keyboard/mouse input.
+pub trait IdleSource: Send {
+    fn idle_ms(&self) -> u64;
+}
+
+/// Real Windows implementation: GetLastInputInfo + GetTickCount.
+pub struct SystemIdle;
+impl IdleSource for SystemIdle { fn idle_ms(&self) -> u64 { /* winapi */ } }
+
+/// Pure, OS-independent decision (unit-tested without Windows).
+pub fn should_screensave(idle_ms: u64, minutes: u64) -> bool {
+    minutes > 0 && idle_ms >= minutes.saturating_mul(60_000)
+}
+```
+
+- `SystemIdle::idle_ms` calls `GetLastInputInfo` (fills `LASTINPUTINFO.dwTime`, a
+  `GetTickCount` timestamp) and computes `GetTickCount().wrapping_sub(dwTime)` to
+  survive the ~49.7-day tick-count wraparound. Returns `0` if the call fails.
+- Requires adding the `sysinfoapi` feature to the `winapi` dependency
+  (`GetTickCount`); `winuser` (already enabled) provides `GetLastInputInfo`.
+
+### 2. `src-tauri/src/screensaver.rs` (new) — the animation (no I/O)
+
+```rust
+pub struct Screensaver { x: i32, y: i32, vx: i32, vy: i32 }
+
+impl Screensaver {
+    pub fn new() -> Self;                 // start near center, vx/vy = (2, 1)
+    /// Advance one step; reflect off edges keeping the text box in bounds.
+    /// If text is wider/taller than the screen, that axis pins at 0 (no jitter).
+    pub fn advance(&mut self, text_w: u32, text_h: u32, screen_w: u32, screen_h: u32);
+    /// Render the time string at the current (x, y) into a fresh OledBuffer.
+    pub fn render(&self, time_str: &str, font: FontSize, w: u32, h: u32) -> OledBuffer;
+}
+
+/// 12-hour H:MM with no am/pm, e.g. "3:42".
+pub fn clock_text(now: &chrono::DateTime<chrono::Local>) -> String; // hour12() + minute()
+```
+
+- DVD bounce: `x += vx; y += vy;` then if the text box would cross an edge, clamp
+  to the edge and negate that velocity component.
+- `render` delegates to `render_text_at` (below). `clock_text` takes the time as a
+  parameter so tests pass a fixed instant.
+
+### 3. `src-tauri/src/render.rs` (small additions)
+
+```rust
+/// Draw `text` at an arbitrary (x, y) text baseline.
+/// (Today's render_text_to_oled positions x but fixes y per text line.)
+pub fn render_text_at(text: &str, x: i32, y: i32, font: FontSize, w: u32, h: u32) -> OledBuffer;
+
+impl FontSize {
+    pub fn char_width(&self) -> u32;   // monospace advance, from profont metrics
+    pub fn char_height(&self) -> u32;  // glyph cell height, from profont metrics
+}
+```
+
+- `char_width`/`char_height` come from the `PROFONT_9/12/18_POINT` font metrics
+  already imported in `render.rs`; the screensaver multiplies `char_width` by the
+  clock string length to size the bounce box.
+
+### 4. `src-tauri/src/settings.rs` (`AppConfig`)
+
+- New field:
+  ```rust
+  #[serde(default)]
+  pub screensaver_idle_minutes: u64,
+  ```
+- Parse in `from_ini`: `main.get("screensaver_idle_minutes").and_then(|v|
+  v.parse::<u64>().ok()).unwrap_or(0)` (missing/invalid → `0` = disabled).
+- `#[serde(default)]` keeps old serialized configs and existing test constructors
+  valid (field defaults to `0`). The test `AppConfig { .. }` literals in
+  daemon.rs/state.rs gain `screensaver_idle_minutes: 0`.
+
+### 5. `src-tauri/src/daemon.rs`
+
+- `Daemon` gains: `screensaver: Screensaver`, `idle_source: Box<dyn IdleSource>`,
+  `screensaver_active: bool`. `Daemon::new` defaults `idle_source` to
+  `Box::new(SystemIdle)`; tests inject a mock.
+- New pure helper kept testable:
+  `fn screensaver_frame(saver: &mut Screensaver, time: &str, font: FontSize,
+  size: (u32,u32)) -> OledBuffer` (advance + render), so a test can assert the
+  buffer changes between ticks.
+- `tick()` gains the branch described in **Behavior** (after the
+  `is_sleeping || is_white_screen` early return, before the HWiNFO pull).
+
+### 6. `src-tauri/src/state.rs` + GUI
+
+- `SharedState` + `StatusPayload`: add `screensaver_active: bool` so the GUI can
+  show a "Screensaver" indicator. Default `false`.
+- `src-tauri/src/gui.rs` → `apply_main_section`: add
+  `.set("screensaver_idle_minutes", config.screensaver_idle_minutes.to_string())`.
+  `AppConfig`'s new serde field round-trips through `get_config`/`save_config`
+  automatically.
+- `src-tauri/ui/index.html`: add a "Screensaver (burn-in protection)" toggle and an
+  idle-minutes number input, following the existing `page-time` pattern:
+  - On load: set the input from `config.screensaver_idle_minutes` (toggle on when
+    `> 0`).
+  - On save: `config.screensaver_idle_minutes = toggle ? (minutes || 5) : 0`.
+  - Enabling the toggle seeds the minutes field with `5` if empty.
+
+## Config schema
+
+```ini
+[Main]
+; 0 = disabled (default). When > 0, the OLED shows a bouncing clock after the
+; PC has been idle (no keyboard/mouse) for this many minutes. Direct-USB only;
+; in GameSense mode the screen blanks instead.
+screensaver_idle_minutes = 5
+```
+
+## Testing plan
+
+- **idle.rs:** `should_screensave` — `0` minutes always false; below/at/above
+  threshold; `saturating_mul` guards overflow. (`SystemIdle` itself is not unit
+  tested — it is a thin winapi shim.)
+- **screensaver.rs:**
+  - `advance` reflects velocity at each edge and never leaves bounds over many steps.
+  - text larger than screen pins the axis instead of oscillating.
+  - `render` lights pixels; position differs after `advance`.
+  - `clock_text` formats a known instant to `H:MM` with no am/pm and no leading zero.
+- **render.rs:** `render_text_at` lights pixels and differs by `y` offset;
+  `char_width/char_height` are non-zero and ordered Small < Medium < Large.
+- **daemon.rs:** with a mock `IdleSource`:
+  - high idle + direct-USB → `screensaver_active` set, a frame is sent (MockDriver),
+    sensor build skipped.
+  - high idle + GameSense → blank sent once, not re-sent on the next idle tick.
+  - low idle after active → flag cleared, normal sensor render resumes.
+  - manual Sleep still short-circuits screensaver.
+- **settings.rs:** parse present/missing/invalid `screensaver_idle_minutes`
+  (→ value / 0 / 0).
+- **gui.rs:** `apply_main_section` writes `screensaver_idle_minutes`; round-trips
+  through save/get.
+
+## Edge cases
+
+- **Tick-count wraparound:** `wrapping_sub` in `SystemIdle::idle_ms`.
+- **Tiny / non-128×64 screens (e.g. Apex 128×40):** bounce bounds use the live
+  `display_size`; oversized text pins instead of jittering.
+- **Mode switch / reload while active:** `reload()` reconnects and `save_config`
+  issues `SleepCommand::Wake`; `screensaver_active` is recomputed each tick, so it
+  self-corrects.
+- **Slow motion:** at 500 ms/tick with `vx/vy = (2,1)`, drift is gentle and
+  adequate for burn-in. Speeding up ticks during the screensaver is intentionally
+  out of scope (would touch the main loop timing).
+
+## Out of scope / future
+
+- Multiple screensaver styles (logo, starfield, drifting sensors).
+- GameSense coarse-bounce (cycling the clock across the three text lines).
+- Faster animation frame rate during the screensaver.
+- Dimming/brightness control (not exposed by the current send paths).

--- a/examples/steelseries-json.rs
+++ b/examples/steelseries-json.rs
@@ -1,0 +1,48 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Event {
+    game: String,
+    event: String,
+    data: Data,
+}
+
+#[derive(Serialize)]
+struct Data{
+    value: u8
+}
+
+impl Event {
+    fn new(game: String, event: String, data: Data) -> Self {
+        Event { game, event, data }
+    }
+}
+
+struct RegisterGame {
+    game: String,
+    game_display_name: String,
+    developer: String
+}
+
+#[derive(Serialize)]
+struct RegisterEvent {
+    game: String,
+    event: String,
+    min_value: Option<u8>,
+    max_value: Option<u8>,
+    icon_id: Option<u8>,
+    value_optional: bool
+}
+
+fn main() {
+   let register = RegisterEvent {
+        game: "game".to_string(),
+        event: "event".to_string(),
+        min_value: Some(0),
+        max_value: Some(100),
+        icon_id: Some(1),
+        value_optional: false
+    };
+   
+   println!("{}", serde_json::to_string(&register).unwrap())
+}

--- a/src-tauri/src/connect.rs
+++ b/src-tauri/src/connect.rs
@@ -148,6 +148,10 @@ pub fn supported_device(d: &hidapi::DeviceInfo) -> Option<&'static SupportedDevi
     find_supported(d.product_id())
 }
 
+/// Suffix of the unsupported-device error; also used to detect that error
+/// class for fail-fast handling in `connect_hid`.
+pub const UNSUPPORTED_ERROR_SUFFIX: &str = "not yet supported for direct USB";
+
 /// Error text naming detected-but-unsupported devices. `detected` pairs the
 /// USB product string (may be empty) with the PID.
 pub fn unsupported_devices_error(detected: &[(String, u16)]) -> String {
@@ -163,7 +167,7 @@ pub fn unsupported_devices_error(detected: &[(String, u16)]) -> String {
         })
         .collect::<Vec<_>>()
         .join(", ");
-    format!("Detected {} — not yet supported for direct USB", list)
+    format!("Detected {} — {}", list, UNSUPPORTED_ERROR_SUFFIX)
 }
 
 /// Finds the supported OLED device matching the optional selector, returning
@@ -187,10 +191,14 @@ pub fn find_hid_device<'a>(
         .filter(|d| supported_device(d).is_some())
         .collect();
     if candidates.is_empty() {
-        let detected: Vec<(String, u16)> = oled_devices
-            .iter()
-            .map(|d| (d.product_string().unwrap_or("").to_string(), d.product_id()))
-            .collect();
+        // Dedupe by PID: a device exposing several OLED-capable interfaces
+        // should be listed once, not once per interface.
+        let mut detected: Vec<(String, u16)> = Vec::new();
+        for d in &oled_devices {
+            if !detected.iter().any(|(_, pid)| *pid == d.product_id()) {
+                detected.push((d.product_string().unwrap_or("").to_string(), d.product_id()));
+            }
+        }
         return Err(anyhow::anyhow!(unsupported_devices_error(&detected)));
     }
     let chosen = if let Some(wanted_path) = selector.strip_prefix("path:") {
@@ -235,6 +243,14 @@ pub fn connect_hid(
     api: &HidApi,
     serial: &str,
 ) -> Result<(HidDevice, &'static SupportedDevice), anyhow::Error> {
+    // A registry miss can't be fixed by retrying; bail immediately so the
+    // daemon's outer reconnect loop surfaces the named error in GUI status
+    // (it still re-probes every 3s, picking up newly plugged devices).
+    if let Err(e) = find_hid_device(api, serial) {
+        if e.to_string().contains(UNSUPPORTED_ERROR_SUFFIX) {
+            return Err(e);
+        }
+    }
     retry_connect(term, "SteelSeries OLED (HID)", || {
         let (device_info, supported) = find_hid_device(api, serial)?;
 
@@ -749,6 +765,8 @@ mod tests {
         assert!(msg.contains("SteelSeries Something (PID 0x1234)"));
         assert!(msg.contains("unknown device (PID 0xABCD)"));
         assert!(msg.contains("not yet supported for direct USB"));
+        // The fail-fast check in connect_hid keys off this exact suffix.
+        assert!(msg.ends_with(UNSUPPORTED_ERROR_SUFFIX));
     }
 
     #[test]

--- a/src-tauri/src/connect.rs
+++ b/src-tauri/src/connect.rs
@@ -1,3 +1,4 @@
+use crate::devices::{find_supported, SupportedDevice};
 use console::Term;
 use gamesense::client::GameSenseClient;
 use hidapi::{HidApi, HidDevice};
@@ -139,54 +140,109 @@ pub fn list_oled_devices(api: &HidApi) -> Vec<&hidapi::DeviceInfo> {
     api.device_list().filter(|d| is_oled_capable(d)).collect()
 }
 
-/// Finds the OLED device matching the optional selector. Empty selector or
-/// no match returns the first OLED-capable device. A selector prefixed with
-/// `path:` matches against the platform HID device path (used when the
-/// device exposes no USB serial number); otherwise it is matched as a serial.
+/// Registry entry for a discovered HID interface, if the device is supported.
+pub fn supported_device(d: &hidapi::DeviceInfo) -> Option<&'static SupportedDevice> {
+    if !is_oled_capable(d) {
+        return None;
+    }
+    find_supported(d.product_id())
+}
+
+/// Error text naming detected-but-unsupported devices. `detected` pairs the
+/// USB product string (may be empty) with the PID.
+pub fn unsupported_devices_error(detected: &[(String, u16)]) -> String {
+    let list = detected
+        .iter()
+        .map(|(name, pid)| {
+            let shown = if name.is_empty() {
+                "unknown device"
+            } else {
+                name
+            };
+            format!("{} (PID 0x{:04X})", shown, pid)
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("Detected {} — not yet supported for direct USB", list)
+}
+
+/// Finds the supported OLED device matching the optional selector, returning
+/// it together with its registry entry. Empty selector or no match returns the
+/// first supported OLED-capable device. A selector prefixed with `path:`
+/// matches against the platform HID device path (used when the device exposes
+/// no USB serial number); otherwise it is matched as a serial. OLED-capable
+/// devices whose PID is not in the supported-device registry are rejected
+/// with an error naming each detected model.
 pub fn find_hid_device<'a>(
     api: &'a HidApi,
     selector: &str,
-) -> Result<&'a hidapi::DeviceInfo, anyhow::Error> {
-    let candidates = list_oled_devices(api);
-    if candidates.is_empty() {
+) -> Result<(&'a hidapi::DeviceInfo, &'static SupportedDevice), anyhow::Error> {
+    let oled_devices = list_oled_devices(api);
+    if oled_devices.is_empty() {
         return Err(anyhow::anyhow!("No SteelSeries OLED device found"));
     }
-    if let Some(wanted_path) = selector.strip_prefix("path:") {
-        if let Some(d) = candidates
+    let candidates: Vec<&hidapi::DeviceInfo> = oled_devices
+        .iter()
+        .copied()
+        .filter(|d| supported_device(d).is_some())
+        .collect();
+    if candidates.is_empty() {
+        let detected: Vec<(String, u16)> = oled_devices
+            .iter()
+            .map(|d| (d.product_string().unwrap_or("").to_string(), d.product_id()))
+            .collect();
+        return Err(anyhow::anyhow!(unsupported_devices_error(&detected)));
+    }
+    let chosen = if let Some(wanted_path) = selector.strip_prefix("path:") {
+        match candidates
             .iter()
             .find(|d| d.path().to_string_lossy() == wanted_path)
         {
-            return Ok(*d);
-        }
-        warn!(
-            "Configured device path '{}' not present; falling back to first OLED device",
-            wanted_path
-        );
-        return Ok(candidates[0]);
-    }
-    let serials: Vec<Option<&str>> = candidates.iter().map(|d| d.serial_number()).collect();
-    match pick_oled_index(&serials, selector) {
-        Some(idx) => {
-            if !selector.is_empty() && serials[idx] != Some(selector) {
+            Some(d) => *d,
+            None => {
                 warn!(
-                    "Configured device serial '{}' not present; falling back to first OLED device",
-                    selector
+                    "Configured device path '{}' not present; falling back to first supported OLED device",
+                    wanted_path
                 );
+                candidates[0]
             }
-            Ok(candidates[idx])
         }
-        None => Err(anyhow::anyhow!("No SteelSeries OLED device found")),
-    }
+    } else {
+        let serials: Vec<Option<&str>> = candidates.iter().map(|d| d.serial_number()).collect();
+        match pick_oled_index(&serials, selector) {
+            Some(idx) => {
+                if !selector.is_empty() && serials[idx] != Some(selector) {
+                    warn!(
+                        "Configured device serial '{}' not present; falling back to first supported OLED device",
+                        selector
+                    );
+                }
+                candidates[idx]
+            }
+            None => return Err(anyhow::anyhow!("No SteelSeries OLED device found")),
+        }
+    };
+    Ok((
+        chosen,
+        supported_device(chosen).expect("candidates are pre-filtered"),
+    ))
 }
 
-pub fn connect_hid(term: &Term, api: &HidApi, serial: &str) -> Result<HidDevice, anyhow::Error> {
+/// Connects to a supported SteelSeries OLED device over HID, returning the
+/// opened device together with its supported-device registry entry.
+pub fn connect_hid(
+    term: &Term,
+    api: &HidApi,
+    serial: &str,
+) -> Result<(HidDevice, &'static SupportedDevice), anyhow::Error> {
     retry_connect(term, "SteelSeries OLED (HID)", || {
-        let device_info = find_hid_device(api, serial)?;
+        let (device_info, supported) = find_hid_device(api, serial)?;
 
-        device_info.open_device(api).map_err(|e| {
+        let device = device_info.open_device(api).map_err(|e| {
             error!("Failed to open HID device: {}", e);
             anyhow::anyhow!("Failed to open HID device: {}", e)
-        })
+        })?;
+        Ok((device, supported))
     })
 }
 
@@ -341,7 +397,14 @@ mod tests {
         let _hwinfo_fn: fn(&Term) -> Result<Hwinfo, anyhow::Error> = connect_hwinfo;
         let _steelseries_fn: fn(&Term) -> Result<GameSenseClient, anyhow::Error> =
             connect_steelseries;
-        let _hid_fn: fn(&Term, &HidApi, &str) -> Result<HidDevice, anyhow::Error> = connect_hid;
+        let _hid_fn: fn(
+            &Term,
+            &HidApi,
+            &str,
+        ) -> Result<
+            (HidDevice, &'static crate::devices::SupportedDevice),
+            anyhow::Error,
+        > = connect_hid;
     }
 
     // ==========================================================================
@@ -527,8 +590,12 @@ mod tests {
         };
         // Filter on HID_VENDOR_ID+usage page is unlikely to match a generic test box.
         if !list_oled_devices(&api).is_empty() {
-            // SteelSeries device present — find should succeed.
-            assert!(find_hid_device(&api, "").is_ok());
+            // SteelSeries device present — find should succeed for a supported
+            // model, or report the detected models as unsupported.
+            match find_hid_device(&api, "") {
+                Ok((_info, _supported)) => {}
+                Err(e) => assert!(e.to_string().contains("not yet supported")),
+            }
             return;
         }
         let r = find_hid_device(&api, "");
@@ -557,17 +624,25 @@ mod tests {
             return;
         };
         let candidates = list_oled_devices(&api);
-        let Some(first) = candidates.first() else {
+        if candidates.is_empty() {
             // No OLED device present — just verify the path selector still
             // surfaces the "no device" error rather than panicking.
             let r = find_hid_device(&api, "path:nonexistent");
             assert!(r.is_err());
             return;
+        }
+        let Some(first) = candidates.iter().find(|d| supported_device(d).is_some()) else {
+            // OLED devices present but none supported — the path selector
+            // must surface the unsupported-device error.
+            let r = find_hid_device(&api, "path:nonexistent");
+            assert!(r.unwrap_err().to_string().contains("not yet supported"));
+            return;
         };
         let path = first.path().to_string_lossy().into_owned();
         let r = find_hid_device(&api, &format!("path:{}", path));
         assert!(r.is_ok());
-        assert_eq!(r.unwrap().path().to_string_lossy(), path);
+        let (info, _supported) = r.unwrap();
+        assert_eq!(info.path().to_string_lossy(), path);
     }
 
     #[test]
@@ -575,12 +650,17 @@ mod tests {
         let Some(api) = try_hid_api_for_connect() else {
             return;
         };
-        if list_oled_devices(&api).is_empty() {
+        let candidates = list_oled_devices(&api);
+        if candidates.is_empty() {
             return;
         }
-        // Bogus path → fallback to first OLED device, not an error.
         let r = find_hid_device(&api, "path:does-not-exist");
-        assert!(r.is_ok());
+        if candidates.iter().any(|d| supported_device(d).is_some()) {
+            // Bogus path → fallback to first supported OLED device, not an error.
+            let (_info, _supported) = r.unwrap();
+        } else {
+            assert!(r.unwrap_err().to_string().contains("not yet supported"));
+        }
     }
 
     /// Set the bounded retry budget for the current test thread.
@@ -615,9 +695,14 @@ mod tests {
         let Some(api) = try_hid_api_for_connect() else {
             return;
         };
-        if !list_oled_devices(&api).is_empty() {
-            return; // SteelSeries device present, skip negative test
+        if list_oled_devices(&api)
+            .iter()
+            .any(|d| supported_device(d).is_some())
+        {
+            return; // supported SteelSeries device present, skip negative test
         }
+        // No supported device → connect_hid must propagate an error, whether
+        // "no device found" or "not yet supported".
         set_test_retry_max(Some(1));
         let term = Term::stdout();
         let r = connect_hid(&term, &api, "");
@@ -653,6 +738,37 @@ mod tests {
         assert_eq!(calls.get(), 2);
         // First failure → 3 sleep_fn calls (countdown), second failure → no further sleeps before returning Err.
         assert_eq!(sleep_calls.get(), 3);
+    }
+
+    #[test]
+    fn test_unsupported_devices_error_lists_models() {
+        let msg = unsupported_devices_error(&[
+            ("SteelSeries Something".to_string(), 0x1234u16),
+            ("".to_string(), 0xABCD),
+        ]);
+        assert!(msg.contains("SteelSeries Something (PID 0x1234)"));
+        assert!(msg.contains("unknown device (PID 0xABCD)"));
+        assert!(msg.contains("not yet supported for direct USB"));
+    }
+
+    #[test]
+    fn test_find_hid_device_returns_supported_entry_when_present() {
+        let Some(api) = try_hid_api_for_connect() else {
+            return;
+        };
+        match find_hid_device(&api, "") {
+            Ok((info, supported)) => {
+                // Whatever matched must be a registry device.
+                assert!(supported.product_ids.contains(&info.product_id()));
+            }
+            Err(e) => {
+                let s = e.to_string();
+                assert!(
+                    s.contains("No SteelSeries OLED") || s.contains("not yet supported"),
+                    "unexpected error: {s}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -1,5 +1,6 @@
 use crate::connect::{connect_hid, connect_hwinfo, connect_steelseries};
 use crate::consts::{CUSTOM_SENSORS, DISPLAY_LINES, TICK_RATE};
+use crate::devices::Protocol;
 use crate::media::MediaReader;
 use crate::mouse_battery::MouseBatteryReader;
 use crate::render::{render_text_to_oled, FontSize, OledBuffer};
@@ -137,14 +138,6 @@ fn buffer_to_rgba_grayscale(buf: &OledBuffer) -> Vec<u8> {
     pixels
 }
 
-/// Pure helper: build a single HID feature-report packet for a 64-px-tall column slice.
-fn build_hid_packet(chunk_x: u8, chunk_width: u8, screen_height: u8, bitmap: &[u8]) -> Vec<u8> {
-    let mut packet = vec![0x06u8, 0x93, chunk_x, 0, chunk_width, screen_height];
-    packet.extend_from_slice(bitmap);
-    packet.resize(1024, 0);
-    packet
-}
-
 /// Pure helper: create an OledBuffer with every pixel turned on ("white" screen).
 fn white_buffer() -> OledBuffer {
     let mut buffer = OledBuffer::new(128, 64);
@@ -154,17 +147,6 @@ fn white_buffer() -> OledBuffer {
         }
     }
     buffer
-}
-
-/// Pure helper: build the two HID packets that cover the entire 128×64 OLED.
-fn build_hid_packets_for_buffer(buffer: &OledBuffer) -> Vec<Vec<u8>> {
-    [0u8, 64u8]
-        .iter()
-        .map(|&chunk_x| {
-            let chunk_bitmap = buffer.get_chunk(chunk_x, 64);
-            build_hid_packet(chunk_x, 64, 64, &chunk_bitmap)
-        })
-        .collect()
 }
 
 /// Display driver abstraction so the daemon can be tested with mocks.
@@ -232,7 +214,9 @@ impl OledClient {
                 client.trigger_event_frame(event, i, value.clone())?;
             }
             OledClient::Hid(sender) => {
-                for packet in build_hid_packets_for_buffer(buffer) {
+                // TEMPORARY: hardcoded Nova Pro until Task 5 threads the
+                // matched SupportedDevice through connect/daemon.
+                for packet in Protocol::NovaPro.build_packets(buffer) {
                     if let Err(e) = sender.send_feature_report(&packet) {
                         error!("Failed to send HID frame: {}", e);
                         return Err(anyhow!("HID send failed: {}", e));
@@ -250,7 +234,7 @@ impl OledClient {
                 client.trigger_event_frame("BLANK", 0, v)?;
             }
             OledClient::Hid(sender) => {
-                for packet in build_hid_packets_for_buffer(&OledBuffer::new(128, 64)) {
+                for packet in Protocol::NovaPro.build_packets(&OledBuffer::new(128, 64)) {
                     let _ = sender.send_feature_report(&packet);
                 }
             }
@@ -270,7 +254,7 @@ impl OledClient {
             }
             OledClient::Hid(sender) => {
                 let buffer = white_buffer();
-                for packet in build_hid_packets_for_buffer(&buffer) {
+                for packet in Protocol::NovaPro.build_packets(&buffer) {
                     let _ = sender.send_feature_report(&packet);
                 }
             }
@@ -1741,38 +1725,6 @@ mod tests {
     fn test_oled_client_hid_send_white_ignores_sender_err() {
         let mut oled = OledClient::Hid(Box::new(FakeHidSender::failing()));
         oled.send_white().unwrap();
-    }
-
-    #[test]
-    fn test_build_hid_packet_header_layout() {
-        let bitmap = vec![0xAB; 100];
-        let p = build_hid_packet(64, 32, 48, &bitmap);
-        assert_eq!(p[0], 0x06);
-        assert_eq!(p[1], 0x93);
-        assert_eq!(p[2], 64); // chunk_x
-        assert_eq!(p[3], 0);
-        assert_eq!(p[4], 32); // chunk_width
-        assert_eq!(p[5], 48); // screen_height
-                              // Bitmap follows
-        assert_eq!(p[6], 0xAB);
-        assert_eq!(p[105], 0xAB);
-        // Padded to 1024
-        assert_eq!(p.len(), 1024);
-        assert_eq!(p[1023], 0);
-    }
-
-    #[test]
-    fn test_build_hid_packets_for_buffer_produces_two_packets() {
-        let buf = OledBuffer::new(128, 64);
-        let packets = build_hid_packets_for_buffer(&buf);
-        assert_eq!(packets.len(), 2);
-        assert_eq!(packets[0][2], 0); // chunk_x = 0
-        assert_eq!(packets[1][2], 64); // chunk_x = 64
-        for p in &packets {
-            assert_eq!(p.len(), 1024);
-            assert_eq!(p[0], 0x06);
-            assert_eq!(p[1], 0x93);
-        }
     }
 
     #[test]

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -1767,7 +1767,7 @@ mod tests {
     }
 
     #[test]
-    fn test_oled_client_hid_apex_sends_single_641_byte_packet() {
+    fn test_oled_client_hid_apex_sends_single_642_byte_packet() {
         let (sender, calls) = FakeHidSender::with_shared_calls();
         let mut oled = OledClient::Hid {
             sender: Box::new(sender),
@@ -1778,7 +1778,7 @@ mod tests {
         oled.trigger_frame("E", 0, &val, &buf).unwrap();
         let packets = calls.lock().unwrap();
         assert_eq!(packets.len(), 1);
-        assert_eq!(packets[0].len(), 641);
+        assert_eq!(packets[0].len(), 642);
         assert_eq!(packets[0][0], 0x61);
     }
 

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -147,7 +147,7 @@ fn build_hid_packet(chunk_x: u8, chunk_width: u8, screen_height: u8, bitmap: &[u
 
 /// Pure helper: create an OledBuffer with every pixel turned on ("white" screen).
 fn white_buffer() -> OledBuffer {
-    let mut buffer = OledBuffer::new();
+    let mut buffer = OledBuffer::new(128, 64);
     for x in 0..128 {
         for y in 0..64 {
             buffer.set_pixel(x, y, true);
@@ -250,7 +250,7 @@ impl OledClient {
                 client.trigger_event_frame("BLANK", 0, v)?;
             }
             OledClient::Hid(sender) => {
-                for packet in build_hid_packets_for_buffer(&OledBuffer::new()) {
+                for packet in build_hid_packets_for_buffer(&OledBuffer::new(128, 64)) {
                     let _ = sender.send_feature_report(&packet);
                 }
             }
@@ -665,7 +665,7 @@ impl<R: Runtime> Daemon<R> {
 
             self.write_state(|s| {
                 s.hwinfo_connected = false;
-                s.oled_buffer = OledBuffer { data: buffer.data };
+                s.oled_buffer = buffer.clone();
                 s.sensor_values = value_to_sensor_values(&value);
                 s.last_error = Some("HWiNFO disconnected".to_string());
             });
@@ -712,7 +712,7 @@ impl<R: Runtime> Daemon<R> {
 
         self.write_state(|s| {
             s.hwinfo_connected = true;
-            s.oled_buffer = OledBuffer { data: buffer.data };
+            s.oled_buffer = buffer.clone();
             s.sensor_values = value_to_sensor_values(&value);
             s.last_error = None;
             s.media_info = media_snapshot;
@@ -1264,7 +1264,7 @@ mod tests {
     #[test]
     fn test_daemon_push_frame_runs() {
         let d = daemon_for_tests();
-        d.push_frame(&OledBuffer::new());
+        d.push_frame(&OledBuffer::new(128, 64));
     }
 
     #[test]
@@ -1677,7 +1677,7 @@ mod tests {
     #[test]
     fn test_oled_client_hid_trigger_frame_sends_two_packets() {
         let mut oled = OledClient::Hid(Box::new(FakeHidSender::new()));
-        let buf = OledBuffer::new();
+        let buf = OledBuffer::new(128, 64);
         let val = json!({});
         oled.trigger_frame("E", 0, &val, &buf).unwrap();
         // FakeHidSender should have received 2 packets
@@ -1691,7 +1691,7 @@ mod tests {
     #[test]
     fn test_oled_client_hid_trigger_frame_returns_err_when_sender_fails() {
         let mut oled = OledClient::Hid(Box::new(FakeHidSender::failing()));
-        let buf = OledBuffer::new();
+        let buf = OledBuffer::new(128, 64);
         let val = json!({});
         let r = oled.trigger_frame("E", 0, &val, &buf);
         assert!(r.is_err());
@@ -1715,7 +1715,7 @@ mod tests {
         // Exercise OledClient's DisplayDriver impl via dyn dispatch (covers the trait wrapper methods).
         let mut drv: Box<dyn DisplayDriver> =
             Box::new(OledClient::Hid(Box::new(FakeHidSender::new())));
-        let buf = OledBuffer::new();
+        let buf = OledBuffer::new(128, 64);
         let val = json!({});
         assert!(drv.trigger_frame("E", 0, &val, &buf).is_ok());
         assert!(drv.send_blank().is_ok());
@@ -1763,7 +1763,7 @@ mod tests {
 
     #[test]
     fn test_build_hid_packets_for_buffer_produces_two_packets() {
-        let buf = OledBuffer::new();
+        let buf = OledBuffer::new(128, 64);
         let packets = build_hid_packets_for_buffer(&buf);
         assert_eq!(packets.len(), 2);
         assert_eq!(packets[0][2], 0); // chunk_x = 0
@@ -1786,7 +1786,7 @@ mod tests {
     fn test_oled_client_dyn_dispatch_via_mock() {
         // Exercise the trait methods through dyn dispatch.
         let mut drv: Box<dyn DisplayDriver> = Box::new(MockDriver::new());
-        let buf = OledBuffer::new();
+        let buf = OledBuffer::new(128, 64);
         let val = json!({});
         assert!(drv.trigger_frame("e", 0, &val, &buf).is_ok());
         assert!(drv.send_blank().is_ok());
@@ -1796,7 +1796,7 @@ mod tests {
 
     #[test]
     fn test_buffer_to_rgba_grayscale_size_and_mapping() {
-        let mut buf = OledBuffer::new();
+        let mut buf = OledBuffer::new(128, 64);
         buf.set_pixel(0, 0, true);
         buf.set_pixel(127, 63, true);
         let px = buffer_to_rgba_grayscale(&buf);

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -122,19 +122,6 @@ fn value_to_sensor_values(value: &Value) -> Vec<SensorValue> {
     out
 }
 
-fn buffer_to_rgba_grayscale(buf: &OledBuffer) -> Vec<u8> {
-    let mut pixels = Vec::with_capacity((buf.width * buf.height) as usize);
-    let pages = (buf.height / 8) as usize;
-    for y in 0..buf.height {
-        for x in 0..buf.width {
-            let idx = x as usize * pages + (y / 8) as usize;
-            let on = (buf.data[idx] & (1 << (y % 8))) != 0;
-            pixels.push(if on { 255 } else { 0 });
-        }
-    }
-    pixels
-}
-
 /// Pure helper: create an OledBuffer with every pixel turned on ("white" screen).
 fn white_buffer(width: u32, height: u32) -> OledBuffer {
     let mut buffer = OledBuffer::new(width, height);
@@ -443,8 +430,7 @@ impl<R: Runtime> Daemon<R> {
     }
 
     fn push_frame(&self, buf: &OledBuffer) {
-        let pixels = buffer_to_rgba_grayscale(buf);
-        let _ = self.app.emit("frame", pixels);
+        let _ = self.app.emit("frame", crate::gui::buffer_to_frame(buf));
     }
 
     fn announce_connecting_hwinfo(&self) {
@@ -528,6 +514,8 @@ impl<R: Runtime> Daemon<R> {
                 supported.name, supported.width, supported.height
             );
             self.display_size = (supported.width, supported.height);
+            let size = self.display_size;
+            self.write_state(|s| s.display_size = size);
             self.oled = Some(Box::new(OledClient::Hid {
                 sender: Box::new(device),
                 device: supported,
@@ -537,6 +525,8 @@ impl<R: Runtime> Daemon<R> {
             self.after_direct_usb_connected();
         } else {
             self.display_size = (128, 64);
+            let size = self.display_size;
+            self.write_state(|s| s.display_size = size);
             self.announce_connecting_gamesense();
 
             let mut gg = connect_steelseries(&self.term)?;
@@ -1809,17 +1799,5 @@ mod tests {
         assert!(drv.send_blank().is_ok());
         assert!(drv.send_white().is_ok());
         assert!(drv.stop_heartbeat().is_ok());
-    }
-
-    #[test]
-    fn test_buffer_to_rgba_grayscale_size_and_mapping() {
-        let mut buf = OledBuffer::new(128, 64);
-        buf.set_pixel(0, 0, true);
-        buf.set_pixel(127, 63, true);
-        let px = buffer_to_rgba_grayscale(&buf);
-        assert_eq!(px.len(), 128 * 64);
-        assert_eq!(px[0], 255); // (0,0)
-        assert_eq!(px[63 * 128 + 127], 255); // (127,63)
-        assert_eq!(px[1], 0); // (1,0) unlit
     }
 }

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -1,6 +1,5 @@
 use crate::connect::{connect_hid, connect_hwinfo, connect_steelseries};
 use crate::consts::{CUSTOM_SENSORS, DISPLAY_LINES, TICK_RATE};
-use crate::devices::Protocol;
 use crate::media::MediaReader;
 use crate::mouse_battery::MouseBatteryReader;
 use crate::render::{render_text_to_oled, FontSize, OledBuffer};
@@ -137,10 +136,10 @@ fn buffer_to_rgba_grayscale(buf: &OledBuffer) -> Vec<u8> {
 }
 
 /// Pure helper: create an OledBuffer with every pixel turned on ("white" screen).
-fn white_buffer() -> OledBuffer {
-    let mut buffer = OledBuffer::new(128, 64);
-    for x in 0..128 {
-        for y in 0..64 {
+fn white_buffer(width: u32, height: u32) -> OledBuffer {
+    let mut buffer = OledBuffer::new(width, height);
+    for x in 0..width {
+        for y in 0..height {
             buffer.set_pixel(x, y, true);
         }
     }
@@ -175,7 +174,10 @@ impl HidSender for hidapi::HidDevice {
 
 enum OledClient {
     GameSense(GameSenseClient),
-    Hid(Box<dyn HidSender>),
+    Hid {
+        sender: Box<dyn HidSender>,
+        device: &'static crate::devices::SupportedDevice,
+    },
 }
 
 impl DisplayDriver for OledClient {
@@ -211,10 +213,8 @@ impl OledClient {
             OledClient::GameSense(client) => {
                 client.trigger_event_frame(event, i, value.clone())?;
             }
-            OledClient::Hid(sender) => {
-                // TEMPORARY: hardcoded Nova Pro until Task 5 threads the
-                // matched SupportedDevice through connect/daemon.
-                for packet in Protocol::NovaPro.build_packets(buffer) {
+            OledClient::Hid { sender, device } => {
+                for packet in device.protocol.build_packets(buffer) {
                     if let Err(e) = sender.send_feature_report(&packet) {
                         error!("Failed to send HID frame: {}", e);
                         return Err(anyhow!("HID send failed: {}", e));
@@ -231,8 +231,9 @@ impl OledClient {
                 let v = json!({ "line1": "", "line2": "", "line3": "" });
                 client.trigger_event_frame("BLANK", 0, v)?;
             }
-            OledClient::Hid(sender) => {
-                for packet in Protocol::NovaPro.build_packets(&OledBuffer::new(128, 64)) {
+            OledClient::Hid { sender, device } => {
+                let blank = OledBuffer::new(device.width, device.height);
+                for packet in device.protocol.build_packets(&blank) {
                     let _ = sender.send_feature_report(&packet);
                 }
             }
@@ -250,9 +251,9 @@ impl OledClient {
                 });
                 client.trigger_event_frame("WHITE", 0, v)?;
             }
-            OledClient::Hid(sender) => {
-                let buffer = white_buffer();
-                for packet in Protocol::NovaPro.build_packets(&buffer) {
+            OledClient::Hid { sender, device } => {
+                let buffer = white_buffer(device.width, device.height);
+                for packet in device.protocol.build_packets(&buffer) {
                     let _ = sender.send_feature_report(&packet);
                 }
             }
@@ -391,6 +392,10 @@ struct Daemon<R: Runtime = tauri::Wry> {
     disconnect_count: usize,
     page_counter: usize,
 
+    /// Active OLED dimensions: registry entry's size in direct-USB mode,
+    /// 128×64 for GameSense.
+    display_size: (u32, u32),
+
     mouse_battery_reader: MouseBatteryReader,
     media_reader: MediaReader,
     weather_reader: crate::weather::WeatherReader,
@@ -414,6 +419,7 @@ impl<R: Runtime> Daemon<R> {
             i: Wrapping(0),
             disconnect_count: 0,
             page_counter: 0,
+            display_size: (128, 64),
             mouse_battery_reader: MouseBatteryReader::new(),
             media_reader: MediaReader::new(),
             weather_reader,
@@ -515,12 +521,22 @@ impl<R: Runtime> Daemon<R> {
             self.announce_connecting_direct_usb();
 
             let api = hidapi::HidApi::new().map_err(|e| anyhow!("HID API init failed: {}", e))?;
-            let device = connect_hid(&self.term, &api, &self.config.direct_usb_serial)?;
-            self.oled = Some(Box::new(OledClient::Hid(Box::new(device))));
+            let (device, supported) =
+                connect_hid(&self.term, &api, &self.config.direct_usb_serial)?;
+            info!(
+                "Direct USB device: {} ({}x{})",
+                supported.name, supported.width, supported.height
+            );
+            self.display_size = (supported.width, supported.height);
+            self.oled = Some(Box::new(OledClient::Hid {
+                sender: Box::new(device),
+                device: supported,
+            }));
             self.hid_api = Some(api);
 
             self.after_direct_usb_connected();
         } else {
+            self.display_size = (128, 64);
             self.announce_connecting_gamesense();
 
             let mut gg = connect_steelseries(&self.term)?;
@@ -642,7 +658,7 @@ impl<R: Runtime> Daemon<R> {
         if disconnected {
             warn!("HWiNFO disconnected");
             let value = disconnected_value();
-            let buffer = value_to_oled_buffer(&value, &self.config.font_sizes, (128, 64));
+            let buffer = value_to_oled_buffer(&value, &self.config.font_sizes, self.display_size);
             let _ = oled.trigger_frame("ERROR", self.i.0, &value, &buffer);
 
             self.write_state(|s| {
@@ -682,7 +698,7 @@ impl<R: Runtime> Daemon<R> {
             self.hid_api.as_ref(),
         )?;
 
-        let buffer = value_to_oled_buffer(&value, &self.config.font_sizes, (128, 64));
+        let buffer = value_to_oled_buffer(&value, &self.config.font_sizes, self.display_size);
         let event_name = page_event_name(self.page_counter);
         oled.trigger_frame(&event_name, self.i.0, &value, &buffer)?;
 
@@ -1627,22 +1643,35 @@ mod tests {
         _arc_assert(Arc::new(()));
     }
 
+    /// Registry entry for the Nova Pro Wireless, the default device used by
+    /// the OledClient::Hid test fixtures.
+    fn nova_device() -> &'static crate::devices::SupportedDevice {
+        crate::devices::find_supported(0x12E0).expect("Nova Pro in registry")
+    }
+
     struct FakeHidSender {
         fail: bool,
-        calls: std::sync::Mutex<Vec<Vec<u8>>>,
+        calls: Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
     }
     impl FakeHidSender {
         fn new() -> Self {
             Self {
                 fail: false,
-                calls: std::sync::Mutex::new(Vec::new()),
+                calls: Arc::new(std::sync::Mutex::new(Vec::new())),
             }
         }
         fn failing() -> Self {
             Self {
                 fail: true,
-                calls: std::sync::Mutex::new(Vec::new()),
+                calls: Arc::new(std::sync::Mutex::new(Vec::new())),
             }
+        }
+        /// Like `new()`, but also hands back the call log so tests can assert
+        /// on packets after the sender is boxed as `dyn HidSender`.
+        fn with_shared_calls() -> (Self, Arc<std::sync::Mutex<Vec<Vec<u8>>>>) {
+            let sender = Self::new();
+            let calls = Arc::clone(&sender.calls);
+            (sender, calls)
         }
     }
     impl HidSender for FakeHidSender {
@@ -1658,21 +1687,26 @@ mod tests {
 
     #[test]
     fn test_oled_client_hid_trigger_frame_sends_two_packets() {
-        let mut oled = OledClient::Hid(Box::new(FakeHidSender::new()));
+        let (sender, calls) = FakeHidSender::with_shared_calls();
+        let mut oled = OledClient::Hid {
+            sender: Box::new(sender),
+            device: nova_device(),
+        };
         let buf = OledBuffer::new(128, 64);
         let val = json!({});
         oled.trigger_frame("E", 0, &val, &buf).unwrap();
-        // FakeHidSender should have received 2 packets
-        if let OledClient::Hid(sender) = &oled {
-            // Downcast not possible without Any, but we know FakeHidSender stores calls.
-            // We'll test via a separate route below.
-            let _ = sender;
-        }
+        // Nova Pro frames are two 1024-byte feature reports.
+        let packets = calls.lock().unwrap();
+        assert_eq!(packets.len(), 2);
+        assert!(packets.iter().all(|p| p.len() == 1024));
     }
 
     #[test]
     fn test_oled_client_hid_trigger_frame_returns_err_when_sender_fails() {
-        let mut oled = OledClient::Hid(Box::new(FakeHidSender::failing()));
+        let mut oled = OledClient::Hid {
+            sender: Box::new(FakeHidSender::failing()),
+            device: nova_device(),
+        };
         let buf = OledBuffer::new(128, 64);
         let val = json!({});
         let r = oled.trigger_frame("E", 0, &val, &buf);
@@ -1682,21 +1716,29 @@ mod tests {
 
     #[test]
     fn test_oled_client_hid_send_blank_writes_packets() {
-        let mut oled = OledClient::Hid(Box::new(FakeHidSender::new()));
+        let mut oled = OledClient::Hid {
+            sender: Box::new(FakeHidSender::new()),
+            device: nova_device(),
+        };
         oled.send_blank().unwrap();
     }
 
     #[test]
     fn test_oled_client_hid_send_white_writes_packets() {
-        let mut oled = OledClient::Hid(Box::new(FakeHidSender::new()));
+        let mut oled = OledClient::Hid {
+            sender: Box::new(FakeHidSender::new()),
+            device: nova_device(),
+        };
         oled.send_white().unwrap();
     }
 
     #[test]
     fn test_oled_client_hid_via_display_driver_trait() {
         // Exercise OledClient's DisplayDriver impl via dyn dispatch (covers the trait wrapper methods).
-        let mut drv: Box<dyn DisplayDriver> =
-            Box::new(OledClient::Hid(Box::new(FakeHidSender::new())));
+        let mut drv: Box<dyn DisplayDriver> = Box::new(OledClient::Hid {
+            sender: Box::new(FakeHidSender::new()),
+            device: nova_device(),
+        });
         let buf = OledBuffer::new(128, 64);
         let val = json!({});
         assert!(drv.trigger_frame("E", 0, &val, &buf).is_ok());
@@ -1707,7 +1749,10 @@ mod tests {
 
     #[test]
     fn test_oled_client_hid_stop_heartbeat_noop() {
-        let mut oled = OledClient::Hid(Box::new(FakeHidSender::new()));
+        let mut oled = OledClient::Hid {
+            sender: Box::new(FakeHidSender::new()),
+            device: nova_device(),
+        };
         // stop_heartbeat is a noop for Hid variant
         oled.stop_heartbeat().unwrap();
     }
@@ -1715,19 +1760,41 @@ mod tests {
     #[test]
     fn test_oled_client_hid_send_blank_ignores_sender_err() {
         // send_blank ignores send errors (best-effort)
-        let mut oled = OledClient::Hid(Box::new(FakeHidSender::failing()));
+        let mut oled = OledClient::Hid {
+            sender: Box::new(FakeHidSender::failing()),
+            device: nova_device(),
+        };
         oled.send_blank().unwrap(); // still Ok even though sender fails
     }
 
     #[test]
     fn test_oled_client_hid_send_white_ignores_sender_err() {
-        let mut oled = OledClient::Hid(Box::new(FakeHidSender::failing()));
+        let mut oled = OledClient::Hid {
+            sender: Box::new(FakeHidSender::failing()),
+            device: nova_device(),
+        };
         oled.send_white().unwrap();
     }
 
     #[test]
+    fn test_oled_client_hid_apex_sends_single_641_byte_packet() {
+        let (sender, calls) = FakeHidSender::with_shared_calls();
+        let mut oled = OledClient::Hid {
+            sender: Box::new(sender),
+            device: crate::devices::find_supported(0x1610).expect("Apex Pro in registry"),
+        };
+        let buf = OledBuffer::new(128, 40);
+        let val = json!({"line1": "x"});
+        oled.trigger_frame("E", 0, &val, &buf).unwrap();
+        let packets = calls.lock().unwrap();
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0].len(), 641);
+        assert_eq!(packets[0][0], 0x61);
+    }
+
+    #[test]
     fn test_white_buffer_all_pixels_on() {
-        let buf = white_buffer();
+        let buf = white_buffer(128, 64);
         // Every byte should be 0xFF
         assert!(buf.data.iter().all(|b| *b == 0xFF));
     }

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -102,8 +102,8 @@ fn value_to_text(value: &Value) -> String {
     text
 }
 
-fn value_to_oled_buffer(value: &Value, font_sizes: &[FontSize]) -> OledBuffer {
-    render_text_to_oled(&value_to_text(value), 0, font_sizes)
+fn value_to_oled_buffer(value: &Value, font_sizes: &[FontSize], size: (u32, u32)) -> OledBuffer {
+    render_text_to_oled(&value_to_text(value), 0, font_sizes, size.0, size.1)
 }
 
 fn value_to_sensor_values(value: &Value) -> Vec<SensorValue> {
@@ -660,7 +660,7 @@ impl<R: Runtime> Daemon<R> {
         if disconnected {
             warn!("HWiNFO disconnected");
             let value = disconnected_value();
-            let buffer = value_to_oled_buffer(&value, &self.config.font_sizes);
+            let buffer = value_to_oled_buffer(&value, &self.config.font_sizes, (128, 64));
             let _ = oled.trigger_frame("ERROR", self.i.0, &value, &buffer);
 
             self.write_state(|s| {
@@ -700,7 +700,7 @@ impl<R: Runtime> Daemon<R> {
             self.hid_api.as_ref(),
         )?;
 
-        let buffer = value_to_oled_buffer(&value, &self.config.font_sizes);
+        let buffer = value_to_oled_buffer(&value, &self.config.font_sizes, (128, 64));
         let event_name = page_event_name(self.page_counter);
         oled.trigger_frame(&event_name, self.i.0, &value, &buffer)?;
 
@@ -1033,7 +1033,7 @@ mod tests {
     #[test]
     fn test_value_to_oled_buffer_populates_text() {
         let v = json!({ "line1": "Hi", "line2": "There", "line3": "" });
-        let buf = value_to_oled_buffer(&v, &[]);
+        let buf = value_to_oled_buffer(&v, &[], (128, 64));
         // Some pixels should be lit
         assert!(buf.data.iter().any(|&b| b != 0));
     }
@@ -1131,7 +1131,7 @@ mod tests {
     #[test]
     fn test_value_to_oled_buffer_with_non_object_value() {
         let v = json!("not an object");
-        let buf = value_to_oled_buffer(&v, &[]);
+        let buf = value_to_oled_buffer(&v, &[], (128, 64));
         // Should produce an empty buffer (no text rendered)
         assert!(buf.data.iter().all(|b| *b == 0));
     }

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -124,14 +124,12 @@ fn value_to_sensor_values(value: &Value) -> Vec<SensorValue> {
 }
 
 fn buffer_to_rgba_grayscale(buf: &OledBuffer) -> Vec<u8> {
-    let mut pixels = Vec::with_capacity(128 * 64);
-    for y in 0..64u32 {
-        for x in 0..128u32 {
-            let col = x as usize;
-            let byte_row = (y / 8) as usize;
-            let bit = (y % 8) as u8;
-            let idx = col * 8 + byte_row;
-            let on = (buf.data[idx] & (1 << bit)) != 0;
+    let mut pixels = Vec::with_capacity((buf.width * buf.height) as usize);
+    let pages = (buf.height / 8) as usize;
+    for y in 0..buf.height {
+        for x in 0..buf.width {
+            let idx = x as usize * pages + (y / 8) as usize;
+            let on = (buf.data[idx] & (1 << (y % 8))) != 0;
             pixels.push(if on { 255 } else { 0 });
         }
     }

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -515,7 +515,10 @@ impl<R: Runtime> Daemon<R> {
             );
             self.display_size = (supported.width, supported.height);
             let size = self.display_size;
-            self.write_state(|s| s.display_size = size);
+            self.write_state(|s| {
+                s.display_size = size;
+                s.oled_buffer = OledBuffer::new(size.0, size.1);
+            });
             self.oled = Some(Box::new(OledClient::Hid {
                 sender: Box::new(device),
                 device: supported,
@@ -526,7 +529,10 @@ impl<R: Runtime> Daemon<R> {
         } else {
             self.display_size = (128, 64);
             let size = self.display_size;
-            self.write_state(|s| s.display_size = size);
+            self.write_state(|s| {
+                s.display_size = size;
+                s.oled_buffer = OledBuffer::new(size.0, size.1);
+            });
             self.announce_connecting_gamesense();
 
             let mut gg = connect_steelseries(&self.term)?;

--- a/src-tauri/src/daemon.rs
+++ b/src-tauri/src/daemon.rs
@@ -376,11 +376,19 @@ fn build_display_value(
             hid_api,
         )?;
 
+        // Per-sensor icon names (direct-USB bitmap path). Read straight from the
+        // page properties, parallel to labels/units, so `run_sensors` stays
+        // unchanged.
+        let icons: Vec<&str> = (0..CUSTOM_SENSORS)
+            .map(|k| pages_sensors.get(format!("icon_{}", k)).unwrap_or_default())
+            .collect();
+
         Ok(format_custom_value(
             config.sensors_per_line,
             labels,
             values,
             units,
+            icons,
         ))
     }
 }
@@ -696,11 +704,19 @@ impl<R: Runtime> Daemon<R> {
         let event_name = page_event_name(self.page_counter);
         oled.trigger_frame(&event_name, self.i.0, &value, &buffer)?;
 
+        // Publish live dynamic-sensor snapshots so the settings preview can render
+        // MEDIA_*/WEATHER_* with the same data the OLED shows (the GUI preview has
+        // no access to the daemon's live readers otherwise).
+        let media_snapshot = self.media_reader.snapshot();
+        let weather_snapshot = self.weather_reader.current_info();
+
         self.write_state(|s| {
             s.hwinfo_connected = true;
             s.oled_buffer = OledBuffer { data: buffer.data };
             s.sensor_values = value_to_sensor_values(&value);
             s.last_error = None;
+            s.media_info = media_snapshot;
+            s.weather_info = weather_snapshot;
         });
         self.push_status();
         self.push_frame(&buffer);

--- a/src-tauri/src/devices.rs
+++ b/src-tauri/src/devices.rs
@@ -10,13 +10,11 @@ pub enum Protocol {
     NovaPro,
     /// Apex 5/7/Pro legacy keyboards: one 641-byte feature report,
     /// 0x61 followed by the 640-byte SSD1306 page-major bitmap.
-    #[allow(dead_code)] // wired up in Task 5 (connect/daemon) and Task 6 (GUI)
     ApexLegacy,
 }
 
 /// One supported direct-USB device model.
 #[derive(Debug)]
-#[allow(dead_code)] // wired up in Task 5 (connect/daemon) and Task 6 (GUI)
 pub struct SupportedDevice {
     /// Display name shown in the GUI device picker.
     pub name: &'static str,
@@ -34,7 +32,6 @@ pub struct SupportedDevice {
 /// PID→model mapping verified against apex-tux (apex-hardware/src/usb.rs).
 /// Apex Gen3 (0x1640/0x1644/0x1646) intentionally absent — different
 /// protocols, not yet implemented.
-#[allow(dead_code)] // wired up in Task 5 (connect/daemon) and Task 6 (GUI)
 pub static SUPPORTED_DEVICES: &[SupportedDevice] = &[
     SupportedDevice {
         name: "Arctis Nova Pro Wireless",
@@ -81,7 +78,6 @@ pub static SUPPORTED_DEVICES: &[SupportedDevice] = &[
 ];
 
 /// Look up the registry entry for a product ID.
-#[allow(dead_code)] // wired up in Task 5 (connect/daemon) and Task 6 (GUI)
 pub fn find_supported(product_id: u16) -> Option<&'static SupportedDevice> {
     SUPPORTED_DEVICES
         .iter()

--- a/src-tauri/src/devices.rs
+++ b/src-tauri/src/devices.rs
@@ -1,0 +1,213 @@
+use crate::render::OledBuffer;
+
+/// HID packet protocol family for a direct-USB OLED device. Each variant
+/// owns the full frame encoding for its device family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+    /// Arctis Nova Pro (Wireless) base station: two 1024-byte feature
+    /// reports, header [0x06, 0x93, chunk_x, 0, 64, height], column-major
+    /// bitmap in 64-column chunks.
+    NovaPro,
+    /// Apex 5/7/Pro legacy keyboards: one 641-byte feature report,
+    /// 0x61 followed by the 640-byte SSD1306 page-major bitmap.
+    #[allow(dead_code)] // wired up in Task 5 (connect/daemon) and Task 6 (GUI)
+    ApexLegacy,
+}
+
+/// One supported direct-USB device model.
+#[derive(Debug)]
+#[allow(dead_code)] // wired up in Task 5 (connect/daemon) and Task 6 (GUI)
+pub struct SupportedDevice {
+    /// Display name shown in the GUI device picker.
+    pub name: &'static str,
+    pub product_ids: &'static [u16],
+    pub width: u32,
+    pub height: u32,
+    pub protocol: Protocol,
+}
+
+/// Registry of devices supported in direct-USB mode. VID is always 0x1038
+/// (enforced by the discovery filter in connect.rs). To add a device that
+/// speaks an existing protocol, add a row. A new packet format needs a new
+/// Protocol variant and a build_packets arm.
+///
+/// PID→model mapping verified against apex-tux (apex-hardware/src/usb.rs).
+/// Apex Gen3 (0x1640/0x1644/0x1646) intentionally absent — different
+/// protocols, not yet implemented.
+#[allow(dead_code)] // wired up in Task 5 (connect/daemon) and Task 6 (GUI)
+pub static SUPPORTED_DEVICES: &[SupportedDevice] = &[
+    SupportedDevice {
+        name: "Arctis Nova Pro Wireless",
+        product_ids: &[0x12E0],
+        width: 128,
+        height: 64,
+        protocol: Protocol::NovaPro,
+    },
+    SupportedDevice {
+        name: "Apex Pro",
+        product_ids: &[0x1610],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+    SupportedDevice {
+        name: "Apex 7",
+        product_ids: &[0x1612],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+    SupportedDevice {
+        name: "Apex Pro TKL",
+        product_ids: &[0x1614],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+    SupportedDevice {
+        name: "Apex 7 TKL",
+        product_ids: &[0x1618],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+    SupportedDevice {
+        name: "Apex 5",
+        product_ids: &[0x161C],
+        width: 128,
+        height: 40,
+        protocol: Protocol::ApexLegacy,
+    },
+];
+
+/// Look up the registry entry for a product ID.
+#[allow(dead_code)] // wired up in Task 5 (connect/daemon) and Task 6 (GUI)
+pub fn find_supported(product_id: u16) -> Option<&'static SupportedDevice> {
+    SUPPORTED_DEVICES
+        .iter()
+        .find(|d| d.product_ids.contains(&product_id))
+}
+
+impl Protocol {
+    /// Build the complete HID feature-report sequence for one frame.
+    pub fn build_packets(&self, buf: &OledBuffer) -> Vec<Vec<u8>> {
+        match self {
+            Protocol::NovaPro => [0u8, 64u8]
+                .iter()
+                .map(|&chunk_x| {
+                    let bitmap = buf.get_chunk(chunk_x, 64);
+                    let mut packet = vec![0x06u8, 0x93, chunk_x, 0, 64, buf.height as u8];
+                    packet.extend_from_slice(&bitmap);
+                    packet.resize(1024, 0);
+                    packet
+                })
+                .collect(),
+            Protocol::ApexLegacy => {
+                let mut packet = Vec::with_capacity(641);
+                packet.push(0x61);
+                packet.extend_from_slice(&buf.to_page_major());
+                vec![packet]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_supported_nova_pro() {
+        let d = find_supported(0x12E0).expect("Nova Pro in registry");
+        assert_eq!(d.name, "Arctis Nova Pro Wireless");
+        assert_eq!((d.width, d.height), (128, 64));
+        assert_eq!(d.protocol, Protocol::NovaPro);
+    }
+
+    #[test]
+    fn test_find_supported_apex_pro() {
+        let d = find_supported(0x1610).expect("Apex Pro in registry");
+        assert_eq!(d.name, "Apex Pro");
+        assert_eq!((d.width, d.height), (128, 40));
+        assert_eq!(d.protocol, Protocol::ApexLegacy);
+    }
+
+    #[test]
+    fn test_find_supported_all_apex_legacy_pids() {
+        for pid in [0x1610u16, 0x1612, 0x1614, 0x1618, 0x161C] {
+            let d = find_supported(pid).unwrap_or_else(|| panic!("PID {pid:#06X} missing"));
+            assert_eq!(d.protocol, Protocol::ApexLegacy);
+            assert_eq!((d.width, d.height), (128, 40));
+        }
+    }
+
+    #[test]
+    fn test_find_supported_unknown_pid_is_none() {
+        assert!(find_supported(0x9999).is_none());
+        // Gen3 PIDs are deliberately unsupported for now
+        assert!(find_supported(0x1640).is_none());
+        assert!(find_supported(0x1644).is_none());
+        assert!(find_supported(0x1646).is_none());
+    }
+
+    #[test]
+    fn test_registry_invariants() {
+        for d in SUPPORTED_DEVICES {
+            // Buffer layout requires height % 8 == 0 (silent corruption otherwise).
+            assert_eq!(d.height % 8, 0, "{}: height must be multiple of 8", d.name);
+            assert!(
+                !d.product_ids.is_empty(),
+                "{}: needs at least one PID",
+                d.name
+            );
+        }
+        // No PID may appear in two entries.
+        let mut all: Vec<u16> = SUPPORTED_DEVICES
+            .iter()
+            .flat_map(|d| d.product_ids.iter().copied())
+            .collect();
+        all.sort_unstable();
+        let len_before = all.len();
+        all.dedup();
+        assert_eq!(
+            len_before,
+            all.len(),
+            "duplicate PID across registry entries"
+        );
+    }
+
+    #[test]
+    fn test_nova_pro_packets_layout() {
+        let mut buf = OledBuffer::new(128, 64);
+        buf.set_pixel(0, 0, true); // first byte of chunk 0
+        buf.set_pixel(64, 0, true); // first byte of chunk 1
+
+        let packets = Protocol::NovaPro.build_packets(&buf);
+        assert_eq!(packets.len(), 2);
+        for (i, p) in packets.iter().enumerate() {
+            assert_eq!(p.len(), 1024);
+            assert_eq!(p[0], 0x06);
+            assert_eq!(p[1], 0x93);
+            assert_eq!(p[2], if i == 0 { 0 } else { 64 }); // chunk_x
+            assert_eq!(p[3], 0);
+            assert_eq!(p[4], 64); // chunk width
+            assert_eq!(p[5], 64); // screen height
+            assert_eq!(p[6], 0x01); // pixel at top-left of this chunk
+        }
+    }
+
+    #[test]
+    fn test_apex_legacy_packet_layout() {
+        let mut buf = OledBuffer::new(128, 40);
+        buf.set_pixel(0, 0, true); // page 0, col 0 → payload byte 0
+        buf.set_pixel(127, 39, true); // page 4, col 127 → last payload byte
+
+        let packets = Protocol::ApexLegacy.build_packets(&buf);
+        assert_eq!(packets.len(), 1);
+        let p = &packets[0];
+        assert_eq!(p.len(), 641);
+        assert_eq!(p[0], 0x61);
+        assert_eq!(p[1], 0x01); // (0,0)
+        assert_eq!(p[640], 0x80); // (127,39): bit 7 of page 4
+    }
+}

--- a/src-tauri/src/devices.rs
+++ b/src-tauri/src/devices.rs
@@ -8,8 +8,9 @@ pub enum Protocol {
     /// reports, header [0x06, 0x93, chunk_x, 0, 64, height], column-major
     /// bitmap in 64-column chunks.
     NovaPro,
-    /// Apex 5/7/Pro legacy keyboards: one 641-byte feature report,
-    /// 0x61 followed by the 640-byte SSD1306 page-major bitmap.
+    /// Apex 5/7/Pro legacy keyboards: one 642-byte feature report —
+    /// 0x61, a 640-byte row-major MSB-first bitmap, and a trailing zero
+    /// pad byte.
     ApexLegacy,
 }
 
@@ -99,9 +100,12 @@ impl Protocol {
                 })
                 .collect(),
             Protocol::ApexLegacy => {
-                let mut packet = Vec::with_capacity(641);
+                let mut packet = Vec::with_capacity(642);
                 packet.push(0x61);
-                packet.extend_from_slice(&buf.to_page_major());
+                packet.extend_from_slice(&buf.to_row_major_msb());
+                // Trailing pad byte — the device's feature report is 642 bytes
+                // (apex-tux FB_SIZE = 40 * 128 / 8 + 2).
+                packet.push(0x00);
                 vec![packet]
             }
         }
@@ -195,15 +199,16 @@ mod tests {
     #[test]
     fn test_apex_legacy_packet_layout() {
         let mut buf = OledBuffer::new(128, 40);
-        buf.set_pixel(0, 0, true); // page 0, col 0 → payload byte 0
-        buf.set_pixel(127, 39, true); // page 4, col 127 → last payload byte
+        buf.set_pixel(0, 0, true); // row 0 byte 0 MSB → payload byte 0
+        buf.set_pixel(127, 39, true); // last row, last byte, LSB → payload byte 639
 
         let packets = Protocol::ApexLegacy.build_packets(&buf);
         assert_eq!(packets.len(), 1);
         let p = &packets[0];
-        assert_eq!(p.len(), 641);
+        assert_eq!(p.len(), 642);
         assert_eq!(p[0], 0x61);
-        assert_eq!(p[1], 0x01); // (0,0)
-        assert_eq!(p[640], 0x80); // (127,39): bit 7 of page 4
+        assert_eq!(p[1], 0x80); // (0,0): MSB of first bitmap byte
+        assert_eq!(p[640], 0x01); // (127,39): LSB of last bitmap byte
+        assert_eq!(p[641], 0x00); // trailing pad
     }
 }

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -247,6 +247,13 @@ pub struct HidDeviceInfo {
     /// Platform HID device path. Stable identifier used to target a
     /// specific device interface when no USB serial is exposed.
     pub path: String,
+    /// True when the device is in the direct-USB supported-device registry.
+    pub supported: bool,
+    /// Registry display name when supported, empty otherwise.
+    pub device_name: String,
+    /// Screen size when supported, 0 otherwise.
+    pub width: u32,
+    pub height: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -289,9 +296,9 @@ fn save_config_impl(path: &str, shared: &Shared, config: AppConfig) -> Result<()
     Ok(())
 }
 
-fn get_live_preview_impl(shared: &Shared) -> Result<Vec<u8>, String> {
+fn get_live_preview_impl(shared: &Shared) -> Result<crate::state::OledFrame, String> {
     let g = shared.lock().map_err(|e| e.to_string())?;
-    Ok(buffer_to_pixels(&g.oled_buffer))
+    Ok(buffer_to_frame(&g.oled_buffer))
 }
 
 #[command]
@@ -310,7 +317,7 @@ pub fn save_config(state: State<Shared>, config: AppConfig) -> Result<(), String
 }
 
 #[command]
-pub fn get_live_preview(state: State<Shared>) -> Result<Vec<u8>, String> {
+pub fn get_live_preview(state: State<Shared>) -> Result<crate::state::OledFrame, String> {
     get_live_preview_impl(&state)
 }
 
@@ -320,14 +327,21 @@ pub fn list_hid_devices() -> Result<Vec<HidDeviceInfo>, String> {
     let devices = list_oled_devices(&api);
     Ok(devices
         .iter()
-        .map(|d| HidDeviceInfo {
-            serial: d.serial_number().unwrap_or("").to_string(),
-            product: d.product_string().unwrap_or("").to_string(),
-            manufacturer: d.manufacturer_string().unwrap_or("").to_string(),
-            vendor_id: d.vendor_id(),
-            product_id: d.product_id(),
-            interface_number: d.interface_number(),
-            path: d.path().to_string_lossy().into_owned(),
+        .map(|d| {
+            let entry = crate::connect::supported_device(d);
+            HidDeviceInfo {
+                serial: d.serial_number().unwrap_or("").to_string(),
+                product: d.product_string().unwrap_or("").to_string(),
+                manufacturer: d.manufacturer_string().unwrap_or("").to_string(),
+                vendor_id: d.vendor_id(),
+                product_id: d.product_id(),
+                interface_number: d.interface_number(),
+                path: d.path().to_string_lossy().into_owned(),
+                supported: entry.is_some(),
+                device_name: entry.map(|e| e.name.to_string()).unwrap_or_default(),
+                width: entry.map(|e| e.width).unwrap_or(0),
+                height: entry.map(|e| e.height).unwrap_or(0),
+            }
         })
         .collect())
 }
@@ -346,13 +360,18 @@ pub fn list_sensors(state: State<Shared>) -> Result<Vec<SensorOption>, String> {
     list_sensors_impl(&state)
 }
 
-fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Result<Vec<u8>, String> {
-    let (hwinfo_opt, media_info, weather_info) = {
+fn preview_config_impl(
+    shared: &Shared,
+    config: AppConfig,
+    page: usize,
+) -> Result<crate::state::OledFrame, String> {
+    let (hwinfo_opt, media_info, weather_info, (w, h)) = {
         let g = shared.lock().map_err(|e| e.to_string())?;
         (
             g.hwinfo_snapshot.clone(),
             g.media_info.clone(),
             g.weather_info.clone(),
+            g.display_size,
         )
     };
 
@@ -362,8 +381,8 @@ fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Resul
         let hwinfo = match hwinfo_opt.as_ref() {
             Some(h) => h,
             None => {
-                let buf = render_text_to_oled("HWiNFO not\nconnected", 0, &[], 128, 64);
-                return Ok(buffer_to_pixels(&buf));
+                let buf = render_text_to_oled("HWiNFO not\nconnected", 0, &[], w, h);
+                return Ok(buffer_to_frame(&buf));
             }
         };
 
@@ -395,8 +414,8 @@ fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Resul
             &weather,
             None,
         ) {
-            let buf = render_text_to_oled(&format!("Preview error:\n{}", e), 0, &[], 128, 64);
-            return Ok(buffer_to_pixels(&buf));
+            let buf = render_text_to_oled(&format!("Preview error:\n{}", e), 0, &[], w, h);
+            return Ok(buffer_to_frame(&buf));
         }
 
         let icons: Vec<&str> = (0..CUSTOM_SENSORS)
@@ -406,14 +425,8 @@ fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Resul
         format_custom_value(config.sensors_per_line, labels, values, units, icons)
     };
 
-    let buf = render_text_to_oled(
-        &value_to_preview_text(&value),
-        0,
-        &config.font_sizes,
-        128,
-        64,
-    );
-    Ok(buffer_to_pixels(&buf))
+    let buf = render_text_to_oled(&value_to_preview_text(&value), 0, &config.font_sizes, w, h);
+    Ok(buffer_to_frame(&buf))
 }
 
 #[command]
@@ -421,11 +434,11 @@ pub fn preview_config(
     state: State<Shared>,
     config: AppConfig,
     page: usize,
-) -> Result<Vec<u8>, String> {
+) -> Result<crate::state::OledFrame, String> {
     preview_config_impl(&state, config, page)
 }
 
-fn buffer_to_pixels(buf: &crate::render::OledBuffer) -> Vec<u8> {
+pub(crate) fn buffer_to_frame(buf: &crate::render::OledBuffer) -> crate::state::OledFrame {
     let mut pixels = Vec::with_capacity((buf.width * buf.height) as usize);
     let pages = (buf.height / 8) as usize;
     for y in 0..buf.height {
@@ -435,7 +448,11 @@ fn buffer_to_pixels(buf: &crate::render::OledBuffer) -> Vec<u8> {
             pixels.push(if on { 255 } else { 0 });
         }
     }
-    pixels
+    crate::state::OledFrame {
+        width: buf.width,
+        height: buf.height,
+        pixels,
+    }
 }
 
 fn set_sleep_command(shared: &Shared, cmd: SleepCommand) -> Result<(), String> {
@@ -854,7 +871,7 @@ mod tests {
         );
     }
 
-    // ==================== buffer_to_pixels ====================
+    // ==================== command impls / buffer_to_frame ====================
 
     use crate::state::{ActiveMode, SharedState};
     use std::sync::{Arc, Mutex};
@@ -880,12 +897,14 @@ mod tests {
     }
 
     #[test]
-    fn test_get_live_preview_impl_returns_pixels() {
+    fn test_get_live_preview_impl_returns_frame() {
         let shared = mock_shared(base_config());
-        let pixels = get_live_preview_impl(&shared).unwrap();
-        assert_eq!(pixels.len(), 128 * 64);
+        let frame = get_live_preview_impl(&shared).unwrap();
+        assert_eq!(frame.width, 128);
+        assert_eq!(frame.height, 64);
+        assert_eq!(frame.pixels.len(), 128 * 64);
         // Empty buffer → all zero
-        assert!(pixels.iter().all(|p| *p == 0));
+        assert!(frame.pixels.iter().all(|p| *p == 0));
     }
 
     #[test]
@@ -1072,10 +1091,12 @@ mod tests {
     fn test_preview_config_impl_summary_renders_pixels() {
         let shared = mock_shared(base_config());
         let cfg = base_config();
-        let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
-        assert_eq!(pixels.len(), 128 * 64);
+        let frame = preview_config_impl(&shared, cfg, 0).unwrap();
+        assert_eq!(frame.width, 128);
+        assert_eq!(frame.height, 64);
+        assert_eq!(frame.pixels.len(), 128 * 64);
         // Summary preview text "CPU GPU MEM" should light some pixels.
-        assert!(pixels.iter().any(|p| *p != 0));
+        assert!(frame.pixels.iter().any(|p| *p != 0));
     }
 
     #[test]
@@ -1085,10 +1106,10 @@ mod tests {
         cfg.is_summary = false;
         cfg.custom_sensors = vec![vec![sensor("CPU;Temp")]];
 
-        let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
+        let frame = preview_config_impl(&shared, cfg, 0).unwrap();
         // "HWiNFO not connected" rendered → some pixels lit
-        assert_eq!(pixels.len(), 128 * 64);
-        assert!(pixels.iter().any(|p| *p != 0));
+        assert_eq!(frame.pixels.len(), 128 * 64);
+        assert!(frame.pixels.iter().any(|p| *p != 0));
     }
 
     #[test]
@@ -1101,8 +1122,8 @@ mod tests {
         let mut cfg = base_config();
         cfg.is_summary = false;
         // No custom_sensors for page 0 → empty page → renders blank text
-        let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
-        assert_eq!(pixels.len(), 128 * 64);
+        let frame = preview_config_impl(&shared, cfg, 0).unwrap();
+        assert_eq!(frame.pixels.len(), 128 * 64);
     }
 
     #[test]
@@ -1116,9 +1137,9 @@ mod tests {
         cfg.is_summary = false;
         cfg.custom_sensors = vec![vec![sensor("Nonexistent;Sensor")]];
 
-        let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
+        let frame = preview_config_impl(&shared, cfg, 0).unwrap();
         // Preview error rendered to pixels
-        assert!(pixels.iter().any(|p| *p != 0));
+        assert!(frame.pixels.iter().any(|p| *p != 0));
     }
 
     #[test]
@@ -1137,11 +1158,11 @@ mod tests {
         cfg.is_summary = false;
         cfg.custom_sensors = vec![vec![sensor("MEDIA_TITLE")]];
 
-        let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
+        let frame = preview_config_impl(&shared, cfg, 0).unwrap();
         // The live media title must render → some pixels lit. With the old
         // throwaway MediaReader, nothing was playing → blank frame.
         assert!(
-            pixels.iter().any(|p| *p != 0),
+            frame.pixels.iter().any(|p| *p != 0),
             "live MEDIA_TITLE should render in preview"
         );
     }
@@ -1161,11 +1182,11 @@ mod tests {
         cfg.is_summary = false;
         cfg.custom_sensors = vec![vec![sensor("WEATHER_TEMP")]];
 
-        let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
+        let frame = preview_config_impl(&shared, cfg, 0).unwrap();
         // The live weather temp must render → some pixels lit. With the old
         // disabled WeatherReader, the field was None → blank frame.
         assert!(
-            pixels.iter().any(|p| *p != 0),
+            frame.pixels.iter().any(|p| *p != 0),
             "live WEATHER_TEMP should render in preview"
         );
     }
@@ -1190,19 +1211,53 @@ mod tests {
         if let Ok(v) = list_hid_devices() {
             for d in &v {
                 assert_eq!(d.vendor_id, crate::connect::HID_VENDOR_ID);
+                if d.supported {
+                    assert!(!d.device_name.is_empty());
+                    assert!(d.width > 0);
+                    assert!(d.height > 0);
+                } else {
+                    assert!(d.device_name.is_empty());
+                    assert_eq!(d.width, 0);
+                    assert_eq!(d.height, 0);
+                }
             }
         }
     }
 
     #[test]
-    fn test_buffer_to_pixels_size_and_mapping() {
+    fn test_buffer_to_frame_uses_buffer_dimensions() {
+        let mut buf = OledBuffer::new(128, 40);
+        buf.set_pixel(0, 0, true);
+        let frame = buffer_to_frame(&buf);
+        assert_eq!(frame.width, 128);
+        assert_eq!(frame.height, 40);
+        assert_eq!(frame.pixels.len(), 128 * 40);
+        assert_eq!(frame.pixels[0], 255);
+        assert_eq!(frame.pixels[1], 0);
+    }
+
+    #[test]
+    fn test_buffer_to_frame_128x64_mapping() {
         let mut buf = OledBuffer::new(128, 64);
         buf.set_pixel(0, 0, true);
         buf.set_pixel(127, 63, true);
-        let px = buffer_to_pixels(&buf);
+        let px = buffer_to_frame(&buf).pixels;
         assert_eq!(px.len(), 128 * 64);
         assert_eq!(px[0], 255);
         assert_eq!(px[63 * 128 + 127], 255);
         assert_eq!(px[1], 0);
+    }
+
+    #[test]
+    fn test_preview_config_impl_uses_live_display_size() {
+        let shared = mock_shared(base_config());
+        {
+            let mut g = shared.lock().unwrap();
+            g.display_size = (128, 40);
+        }
+        let frame = preview_config_impl(&shared, base_config(), 0).unwrap();
+        assert_eq!(frame.width, 128);
+        assert_eq!(frame.height, 40);
+        assert_eq!(frame.pixels.len(), 128 * 40);
     }
 }

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -1192,7 +1192,7 @@ mod tests {
 
     #[test]
     fn test_buffer_to_pixels_size_and_mapping() {
-        let mut buf = OledBuffer::new();
+        let mut buf = OledBuffer::new(128, 64);
         buf.set_pixel(0, 0, true);
         buf.set_pixel(127, 63, true);
         let px = buffer_to_pixels(&buf);

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -105,6 +105,7 @@ fn build_preview_props(page_sensors: &[crate::settings::CustomSensor]) -> ini::P
         props.insert(format!("label_{}", k), sensor.label.clone());
         props.insert(format!("unit_{}", k), sensor.unit.clone());
         props.insert(format!("convert_{}", k), sensor.convert.clone());
+        props.insert(format!("icon_{}", k), sensor.icon.clone());
     }
     props
 }
@@ -218,6 +219,7 @@ fn apply_pages_sections(ini: &mut Ini, config: &AppConfig) {
             section.set(format!("label_{}", k), &sensor.label);
             section.set(format!("unit_{}", k), &sensor.unit);
             section.set(format!("convert_{}", k), &sensor.convert);
+            section.set(format!("icon_{}", k), &sensor.icon);
         }
     }
 }
@@ -345,9 +347,13 @@ pub fn list_sensors(state: State<Shared>) -> Result<Vec<SensorOption>, String> {
 }
 
 fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Result<Vec<u8>, String> {
-    let hwinfo_opt = {
+    let (hwinfo_opt, media_info, weather_info) = {
         let g = shared.lock().map_err(|e| e.to_string())?;
-        g.hwinfo_snapshot.clone()
+        (
+            g.hwinfo_snapshot.clone(),
+            g.media_info.clone(),
+            g.weather_info.clone(),
+        )
     };
 
     let value: Value = if config.is_summary {
@@ -369,8 +375,13 @@ fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Resul
         let mut values = vec![String::new(); CUSTOM_SENSORS];
 
         let mut mb = MouseBatteryReader::new();
-        let mut media = MediaReader::new();
-        let weather = crate::weather::WeatherReader::disabled();
+        // Seed the preview readers with the daemon's live snapshots so MEDIA_*/
+        // WEATHER_* sensors render real data instead of always-blank placeholders.
+        let mut media = MediaReader::with_cached_info(media_info);
+        let weather = match weather_info {
+            Some(info) => crate::weather::WeatherReader::with_cached_info(info),
+            None => crate::weather::WeatherReader::disabled(),
+        };
 
         if let Err(e) = run_sensors(
             &props,
@@ -388,7 +399,11 @@ fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Resul
             return Ok(buffer_to_pixels(&buf));
         }
 
-        format_custom_value(config.sensors_per_line, labels, values, units)
+        let icons: Vec<&str> = (0..CUSTOM_SENSORS)
+            .map(|k| props.get(format!("icon_{}", k)).unwrap_or_default())
+            .collect();
+
+        format_custom_value(config.sensors_per_line, labels, values, units, icons)
     };
 
     let buf = render_text_to_oled(&value_to_preview_text(&value), 0, &config.font_sizes);
@@ -473,6 +488,7 @@ mod tests {
             label: format!("L_{}", name),
             unit: "U".to_string(),
             convert: String::new(),
+            icon: String::new(),
         }
     }
 
@@ -524,6 +540,20 @@ mod tests {
         assert_eq!(p.get("label_0"), Some("L_CPU;Temp"));
         assert_eq!(p.get("unit_0"), Some("U"));
         assert_eq!(p.get("convert_0"), Some(""));
+        assert_eq!(p.get("icon_0"), Some(""));
+    }
+
+    #[test]
+    fn test_build_preview_props_writes_icon() {
+        let page = vec![CustomSensor {
+            sensor: "CPU;Temp".to_string(),
+            label: String::new(),
+            unit: String::new(),
+            convert: String::new(),
+            icon: "cpu".to_string(),
+        }];
+        let p = build_preview_props(&page);
+        assert_eq!(p.get("icon_0"), Some("cpu"));
     }
 
     #[test]
@@ -719,6 +749,23 @@ mod tests {
         let sec = ini.section(Some("PAGE1.Sensors")).unwrap();
         assert_eq!(sec.get("sensor_0"), Some("CPU;Temp"));
         assert_eq!(sec.get("sensor_1"), Some("GPU;Temp"));
+    }
+
+    #[test]
+    fn test_apply_pages_sections_writes_icon() {
+        let mut ini = Ini::new();
+        let mut c = base_config();
+        c.is_summary = false;
+        c.custom_sensors = vec![vec![CustomSensor {
+            sensor: "CPU;Temp".to_string(),
+            label: String::new(),
+            unit: String::new(),
+            convert: String::new(),
+            icon: "cpu".to_string(),
+        }]];
+        apply_pages_sections(&mut ini, &c);
+        let sec = ini.section(Some("PAGE1.Sensors")).unwrap();
+        assert_eq!(sec.get("icon_0"), Some("cpu"));
     }
 
     #[test]
@@ -1068,6 +1115,55 @@ mod tests {
         let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
         // Preview error rendered to pixels
         assert!(pixels.iter().any(|p| *p != 0));
+    }
+
+    #[test]
+    fn test_preview_config_impl_renders_live_media() {
+        let shared = mock_shared(base_config());
+        {
+            let mut g = shared.lock().unwrap();
+            g.hwinfo_snapshot = Some(build_hwinfo(&[("CPU", "Temp")]));
+            g.media_info = crate::media::MediaInfo {
+                title: "NowPlaying".to_string(),
+                is_playing: true,
+                ..Default::default()
+            };
+        }
+        let mut cfg = base_config();
+        cfg.is_summary = false;
+        cfg.custom_sensors = vec![vec![sensor("MEDIA_TITLE")]];
+
+        let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
+        // The live media title must render → some pixels lit. With the old
+        // throwaway MediaReader, nothing was playing → blank frame.
+        assert!(
+            pixels.iter().any(|p| *p != 0),
+            "live MEDIA_TITLE should render in preview"
+        );
+    }
+
+    #[test]
+    fn test_preview_config_impl_renders_live_weather() {
+        let shared = mock_shared(base_config());
+        {
+            let mut g = shared.lock().unwrap();
+            g.hwinfo_snapshot = Some(build_hwinfo(&[("CPU", "Temp")]));
+            g.weather_info = Some(crate::weather::WeatherInfo {
+                temp: Some("72".to_string()),
+                ..Default::default()
+            });
+        }
+        let mut cfg = base_config();
+        cfg.is_summary = false;
+        cfg.custom_sensors = vec![vec![sensor("WEATHER_TEMP")]];
+
+        let pixels = preview_config_impl(&shared, cfg, 0).unwrap();
+        // The live weather temp must render → some pixels lit. With the old
+        // disabled WeatherReader, the field was None → blank frame.
+        assert!(
+            pixels.iter().any(|p| *p != 0),
+            "live WEATHER_TEMP should render in preview"
+        );
     }
 
     #[test]

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -362,7 +362,7 @@ fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Resul
         let hwinfo = match hwinfo_opt.as_ref() {
             Some(h) => h,
             None => {
-                let buf = render_text_to_oled("HWiNFO not\nconnected", 0, &[]);
+                let buf = render_text_to_oled("HWiNFO not\nconnected", 0, &[], 128, 64);
                 return Ok(buffer_to_pixels(&buf));
             }
         };
@@ -395,7 +395,7 @@ fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Resul
             &weather,
             None,
         ) {
-            let buf = render_text_to_oled(&format!("Preview error:\n{}", e), 0, &[]);
+            let buf = render_text_to_oled(&format!("Preview error:\n{}", e), 0, &[], 128, 64);
             return Ok(buffer_to_pixels(&buf));
         }
 
@@ -406,7 +406,13 @@ fn preview_config_impl(shared: &Shared, config: AppConfig, page: usize) -> Resul
         format_custom_value(config.sensors_per_line, labels, values, units, icons)
     };
 
-    let buf = render_text_to_oled(&value_to_preview_text(&value), 0, &config.font_sizes);
+    let buf = render_text_to_oled(
+        &value_to_preview_text(&value),
+        0,
+        &config.font_sizes,
+        128,
+        64,
+    );
     Ok(buffer_to_pixels(&buf))
 }
 

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -426,14 +426,12 @@ pub fn preview_config(
 }
 
 fn buffer_to_pixels(buf: &crate::render::OledBuffer) -> Vec<u8> {
-    let mut pixels = Vec::with_capacity(128 * 64);
-    for y in 0..64u32 {
-        for x in 0..128u32 {
-            let col = x as usize;
-            let byte_row = (y / 8) as usize;
-            let bit = (y % 8) as u8;
-            let idx = col * 8 + byte_row;
-            let on = (buf.data[idx] & (1 << bit)) != 0;
+    let mut pixels = Vec::with_capacity((buf.width * buf.height) as usize);
+    let pages = (buf.height / 8) as usize;
+    for y in 0..buf.height {
+        for x in 0..buf.width {
+            let idx = x as usize * pages + (y / 8) as usize;
+            let on = (buf.data[idx] & (1 << (y % 8))) != 0;
             pixels.push(if on { 255 } else { 0 });
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -312,6 +312,13 @@ fn main() -> Result<(), anyhow::Error> {
                 .or_else(|| app.default_window_icon().cloned())
                 .ok_or_else(|| anyhow::anyhow!("Failed to load tray icon"))?;
 
+            // Use the same icon for the main window titlebar/taskbar.
+            if let (Some(win), Some(win_icon)) =
+                (app.get_webview_window("main"), build_tray_icon_image())
+            {
+                let _ = win.set_icon(win_icon);
+            }
+
             let settings_item =
                 MenuItem::with_id(app, "settings", "Settings...", true, None::<&str>)?;
             let reload_item =

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,8 @@ use settings::{settings_create_config, AppConfig};
 
 mod consts;
 
+mod devices;
+
 mod connect;
 use connect::connect_hwinfo;
 

--- a/src-tauri/src/media.rs
+++ b/src-tauri/src/media.rs
@@ -32,6 +32,12 @@ impl MediaReader {
         }
     }
 
+    /// Clone the current cached media info. The daemon publishes this into shared
+    /// state each tick so the GUI preview can seed a reader via `with_cached_info`.
+    pub fn snapshot(&self) -> MediaInfo {
+        self.cached_info.clone()
+    }
+
     /// Initialize the media session manager (blocking)
     /// Should be called once during app initialization
     pub fn initialize(&mut self) -> Result<(), anyhow::Error> {
@@ -203,10 +209,11 @@ impl Default for MediaReader {
     }
 }
 
-#[cfg(test)]
 impl MediaReader {
-    /// Test-only constructor with a pre-populated cache.
-    /// `last_read` is set to now so `get_media_field` returns from cache without touching Windows APIs.
+    /// Constructor with a pre-populated cache and no live manager. `last_read` is
+    /// set to now so `get_media_field` serves the seeded data from cache without
+    /// touching the (absent) Windows API. Used by the settings preview to render
+    /// `MEDIA_*` sensors with the daemon's live data.
     pub fn with_cached_info(info: MediaInfo) -> Self {
         Self {
             cached_info: info,

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -113,7 +113,6 @@ impl OledBuffer {
     /// Serialize to SSD1306 page-major order: all columns of page 0, then
     /// page 1, etc. (The internal layout is column-major pages.) Used by the
     /// Apex legacy protocol.
-    #[allow(dead_code)] // consumed by Protocol::ApexLegacy in devices.rs (Task 4)
     pub fn to_page_major(&self) -> Vec<u8> {
         let pages = self.pages();
         let mut out = Vec::with_capacity(self.data.len());

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -228,8 +228,14 @@ fn get_emoji_icon(emoji: &str) -> Option<&'static [u8; 8]> {
     None
 }
 
-pub fn render_text_to_oled(text: &str, x: i32, line_fonts: &[FontSize]) -> OledBuffer {
-    let mut buffer = OledBuffer::new(128, 64);
+pub fn render_text_to_oled(
+    text: &str,
+    x: i32,
+    line_fonts: &[FontSize],
+    width: u32,
+    height: u32,
+) -> OledBuffer {
+    let mut buffer = OledBuffer::new(width, height);
 
     let mut y = 0;
     for (i, line) in text.lines().enumerate() {
@@ -297,11 +303,11 @@ pub fn load_image_to_buffer(
     let (width, height) = gray.dimensions();
 
     for y in 0..height {
-        if y + y_off >= 64 {
+        if y + y_off >= buffer.height {
             break;
         }
         for x in 0..width {
-            if x + x_off >= 128 {
+            if x + x_off >= buffer.width {
                 break;
             }
             let pixel = gray.get_pixel(x, y);
@@ -657,14 +663,14 @@ mod tests {
     #[test]
     fn test_render_inline_icon_token_lights_pixels() {
         let text = format!("{}Temp", icon_token("cpu"));
-        let buf = render_text_to_oled(&text, 0, &[]);
+        let buf = render_text_to_oled(&text, 0, &[], 128, 64);
         assert!(buf.data.iter().any(|&b| b != 0));
     }
 
     #[test]
     fn test_render_inline_icon_differs_from_plain_text() {
-        let with_icon = render_text_to_oled(&format!("{}42", icon_token("cpu")), 0, &[]);
-        let plain = render_text_to_oled("42", 0, &[]);
+        let with_icon = render_text_to_oled(&format!("{}42", icon_token("cpu")), 0, &[], 128, 64);
+        let plain = render_text_to_oled("42", 0, &[], 128, 64);
         assert_ne!(with_icon.data, plain.data);
     }
 
@@ -672,8 +678,9 @@ mod tests {
     fn test_render_unknown_icon_token_renders_following_text() {
         // Unknown icon name: no glyph, but the trailing text still renders and
         // the delimiter chars must not appear as literal glyphs.
-        let with_bogus = render_text_to_oled(&format!("{}Hi", icon_token("bogus")), 0, &[]);
-        let plain = render_text_to_oled("Hi", 0, &[]);
+        let with_bogus =
+            render_text_to_oled(&format!("{}Hi", icon_token("bogus")), 0, &[], 128, 64);
+        let plain = render_text_to_oled("Hi", 0, &[], 128, 64);
         assert!(with_bogus.data.iter().any(|&b| b != 0));
         assert_eq!(with_bogus.data, plain.data);
     }
@@ -684,14 +691,14 @@ mod tests {
 
     #[test]
     fn test_render_text_empty_string() {
-        let buffer = render_text_to_oled("", 0, &[]);
+        let buffer = render_text_to_oled("", 0, &[], 128, 64);
         // Should return a valid buffer
         assert_eq!(buffer.data.len(), 128 * 8);
     }
 
     #[test]
     fn test_render_text_simple_ascii() {
-        let buffer = render_text_to_oled("Hello", 0, &[]);
+        let buffer = render_text_to_oled("Hello", 0, &[], 128, 64);
         // Buffer should have some pixels set (not all zeros)
         let has_pixels = buffer.data.iter().any(|&b| b != 0);
         assert!(has_pixels, "Text should render some pixels");
@@ -699,29 +706,29 @@ mod tests {
 
     #[test]
     fn test_render_text_multiple_lines() {
-        let buffer = render_text_to_oled("Line1\nLine2\nLine3", 0, &[]);
+        let buffer = render_text_to_oled("Line1\nLine2\nLine3", 0, &[], 128, 64);
         let has_pixels = buffer.data.iter().any(|&b| b != 0);
         assert!(has_pixels, "Multi-line text should render some pixels");
     }
 
     #[test]
     fn test_render_text_with_emoji() {
-        let buffer = render_text_to_oled("🔥 Hot", 0, &[]);
+        let buffer = render_text_to_oled("🔥 Hot", 0, &[], 128, 64);
         let has_pixels = buffer.data.iter().any(|&b| b != 0);
         assert!(has_pixels, "Text with emoji should render some pixels");
     }
 
     #[test]
     fn test_render_text_correct_buffer_dimensions() {
-        let buffer = render_text_to_oled("Test", 0, &[]);
+        let buffer = render_text_to_oled("Test", 0, &[], 128, 64);
         // OriginDimensions should report 128x64
         assert_eq!(buffer.size(), Size::new(128, 64));
     }
 
     #[test]
     fn test_render_text_with_x_offset() {
-        let buffer_no_offset = render_text_to_oled("A", 0, &[]);
-        let buffer_with_offset = render_text_to_oled("A", 50, &[]);
+        let buffer_no_offset = render_text_to_oled("A", 0, &[], 128, 64);
+        let buffer_with_offset = render_text_to_oled("A", 50, &[], 128, 64);
 
         // Both should have pixels, but in different positions
         let has_pixels_no_offset = buffer_no_offset.data.iter().any(|&b| b != 0);
@@ -917,7 +924,7 @@ mod tests {
         write_test_image(&path, 4, 4, 255);
 
         let text = format!("IMG:{}", path.to_string_lossy());
-        let buffer = render_text_to_oled(&text, 0, &[]);
+        let buffer = render_text_to_oled(&text, 0, &[], 128, 64);
         let any_lit = buffer.data.iter().any(|b| *b != 0);
         assert!(any_lit);
 
@@ -973,8 +980,8 @@ mod tests {
 
     #[test]
     fn test_render_small_vs_large_differ() {
-        let small = render_text_to_oled("Hello", 0, &[FontSize::Small]);
-        let large = render_text_to_oled("Hello", 0, &[FontSize::Large]);
+        let small = render_text_to_oled("Hello", 0, &[FontSize::Small], 128, 64);
+        let large = render_text_to_oled("Hello", 0, &[FontSize::Large], 128, 64);
         assert_ne!(small.data, large.data);
     }
 
@@ -984,13 +991,32 @@ mod tests {
             "Big\nsmall\nmed",
             0,
             &[FontSize::Large, FontSize::Small, FontSize::Medium],
+            128,
+            64,
         );
         assert!(buf.data.iter().any(|&b| b != 0));
     }
 
     #[test]
+    fn test_render_text_at_explicit_dimensions() {
+        let buf = render_text_to_oled("Hi", 0, &[], 128, 40);
+        assert_eq!(buf.width, 128);
+        assert_eq!(buf.height, 40);
+        assert_eq!(buf.data.len(), 640);
+        // Something was drawn
+        assert!(buf.data.iter().any(|&b| b != 0));
+    }
+
+    #[test]
+    fn test_render_clips_safely_on_short_screen() {
+        // 5 lines of Large font massively overflow 40px; must not panic.
+        let buf = render_text_to_oled("A\nB\nC\nD\nE", 0, &[FontSize::Large; 5], 128, 40);
+        assert_eq!(buf.data.len(), 640);
+    }
+
+    #[test]
     fn test_render_fewer_fonts_than_lines_falls_back_medium() {
-        let buf = render_text_to_oled("a\nb\nc", 0, &[FontSize::Small]);
+        let buf = render_text_to_oled("a\nb\nc", 0, &[FontSize::Small], 128, 64);
         assert!(buf.data.iter().any(|&b| b != 0));
     }
 }

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -107,6 +107,20 @@ impl OledBuffer {
 
     // clear is omitted as it is currently unused
 
+    /// Serialize to SSD1306 page-major order: all columns of page 0, then
+    /// page 1, etc. (The internal layout is column-major pages.) Used by the
+    /// Apex legacy protocol.
+    pub fn to_page_major(&self) -> Vec<u8> {
+        let pages = self.pages();
+        let mut out = Vec::with_capacity(self.data.len());
+        for page in 0..pages {
+            for x in 0..self.width as usize {
+                out.push(self.data[x * pages + page]);
+            }
+        }
+        out
+    }
+
     pub fn get_chunk(&self, x_offset: u8, width: u8) -> Vec<u8> {
         let pages = self.pages();
         let mut chunk = Vec::with_capacity(width as usize * pages);
@@ -501,6 +515,37 @@ mod tests {
         a.set_pixel(1, 1, true);
         let b = a.clone();
         assert_eq!(a, b);
+        a.set_pixel(2, 2, true);
+        assert_ne!(a, b);
+    }
+
+    // ===========================================
+    // OledBuffer::to_page_major() tests
+    // ===========================================
+
+    #[test]
+    fn test_to_page_major_length_and_ordering() {
+        let mut b = OledBuffer::new(128, 40);
+        // (0,0) → page 0, column 0, bit 0 → out[0] = 0x01
+        b.set_pixel(0, 0, true);
+        // (5,9) → page 1, column 5, bit 1 → out[1*128 + 5] = 0x02
+        b.set_pixel(5, 9, true);
+        // (127,39) → page 4, column 127, bit 7 → out[4*128 + 127] = 0x80
+        b.set_pixel(127, 39, true);
+
+        let out = b.to_page_major();
+        assert_eq!(out.len(), 640);
+        assert_eq!(out[0], 0x01);
+        assert_eq!(out[128 + 5], 0x02);
+        assert_eq!(out[4 * 128 + 127], 0x80);
+    }
+
+    #[test]
+    fn test_to_page_major_empty_buffer_is_zeroes() {
+        let b = OledBuffer::new(128, 64);
+        let out = b.to_page_major();
+        assert_eq!(out.len(), 1024);
+        assert!(out.iter().all(|&byte| byte == 0));
     }
 
     // ===========================================

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -77,7 +77,10 @@ pub struct OledBuffer {
 
 impl OledBuffer {
     pub fn new(width: u32, height: u32) -> Self {
-        debug_assert!(height % 8 == 0, "OLED height must be a multiple of 8");
+        debug_assert!(
+            height.is_multiple_of(8),
+            "OLED height must be a multiple of 8"
+        );
         Self {
             width,
             height,

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -66,27 +66,37 @@ impl FontSize {
     }
 }
 
-/// A buffer for the SteelSeries OLED screen (128x64)
+/// A buffer for a SteelSeries OLED screen. Layout is column-major pages:
+/// for each column, `height/8` bytes; within a byte, bit 0 is the topmost pixel.
+#[derive(Debug, Clone, PartialEq)]
 pub struct OledBuffer {
-    // 128 columns, 8 bytes per column (64 pixels / 8)
-    pub data: [u8; 128 * 8],
+    pub width: u32,
+    pub height: u32,
+    pub data: Vec<u8>,
 }
 
 impl OledBuffer {
-    pub fn new() -> Self {
+    pub fn new(width: u32, height: u32) -> Self {
+        debug_assert!(height % 8 == 0, "OLED height must be a multiple of 8");
         Self {
-            data: [0u8; 128 * 8],
+            width,
+            height,
+            data: vec![0u8; (width * height / 8) as usize],
         }
     }
 
+    /// Bytes per column (= height / 8).
+    fn pages(&self) -> usize {
+        (self.height / 8) as usize
+    }
+
     pub fn set_pixel(&mut self, x: u32, y: u32, on: bool) {
-        if x >= 128 || y >= 64 {
+        if x >= self.width || y >= self.height {
             return;
         }
-        let col = x as usize;
-        let byte_row = (y / 8) as usize;
+        let pages = self.pages();
+        let idx = x as usize * pages + (y / 8) as usize;
         let bit = (y % 8) as u8;
-        let idx = col * 8 + byte_row;
 
         if on {
             self.data[idx] |= 1 << bit;
@@ -98,10 +108,11 @@ impl OledBuffer {
     // clear is omitted as it is currently unused
 
     pub fn get_chunk(&self, x_offset: u8, width: u8) -> Vec<u8> {
-        let mut chunk = Vec::with_capacity(width as usize * 8);
+        let pages = self.pages();
+        let mut chunk = Vec::with_capacity(width as usize * pages);
         for x in x_offset..(x_offset + width) {
-            let start = x as usize * 8;
-            chunk.extend_from_slice(&self.data[start..start + 8]);
+            let start = x as usize * pages;
+            chunk.extend_from_slice(&self.data[start..start + pages]);
         }
         chunk
     }
@@ -116,7 +127,11 @@ impl DrawTarget for OledBuffer {
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
         for Pixel(point, color) in pixels.into_iter() {
-            if point.x >= 0 && point.x < 128 && point.y >= 0 && point.y < 64 {
+            if point.x >= 0
+                && point.x < self.width as i32
+                && point.y >= 0
+                && point.y < self.height as i32
+            {
                 self.set_pixel(point.x as u32, point.y as u32, color.is_on());
             }
         }
@@ -126,7 +141,7 @@ impl DrawTarget for OledBuffer {
 
 impl OriginDimensions for OledBuffer {
     fn size(&self) -> Size {
-        Size::new(128, 64)
+        Size::new(self.width, self.height)
     }
 }
 
@@ -196,7 +211,7 @@ fn get_emoji_icon(emoji: &str) -> Option<&'static [u8; 8]> {
 }
 
 pub fn render_text_to_oled(text: &str, x: i32, line_fonts: &[FontSize]) -> OledBuffer {
-    let mut buffer = OledBuffer::new();
+    let mut buffer = OledBuffer::new(128, 64);
 
     let mut y = 0;
     for (i, line) in text.lines().enumerate() {
@@ -303,14 +318,14 @@ mod tests {
 
     #[test]
     fn test_oled_buffer_new_creates_correct_size() {
-        let buffer = OledBuffer::new();
+        let buffer = OledBuffer::new(128, 64);
         // 128 columns * 8 bytes per column = 1024 bytes
         assert_eq!(buffer.data.len(), 128 * 8);
     }
 
     #[test]
     fn test_oled_buffer_new_initialized_to_zeros() {
-        let buffer = OledBuffer::new();
+        let buffer = OledBuffer::new(128, 64);
         // All bytes should be zero (black/off)
         for byte in buffer.data.iter() {
             assert_eq!(*byte, 0);
@@ -323,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_set_pixel_at_origin() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         buffer.set_pixel(0, 0, true);
 
         // Pixel at (0,0) should set bit 0 of byte at index 0
@@ -332,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_set_pixel_at_max_bounds() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         // Max valid coordinates are (127, 63) for 128x64 display
         buffer.set_pixel(127, 63, true);
 
@@ -344,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_set_pixel_out_of_bounds_x_does_not_panic() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         // Should not panic, just be ignored
         buffer.set_pixel(128, 0, true);
         buffer.set_pixel(200, 0, true);
@@ -357,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_set_pixel_out_of_bounds_y_does_not_panic() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         // Should not panic, just be ignored
         buffer.set_pixel(0, 64, true);
         buffer.set_pixel(0, 100, true);
@@ -370,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_set_pixel_can_turn_off() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         buffer.set_pixel(5, 5, true);
 
         // Verify pixel is on
@@ -385,7 +400,7 @@ mod tests {
 
     #[test]
     fn test_set_pixel_different_y_positions() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
 
         // Set pixels at different y positions in same column
         buffer.set_pixel(0, 0, true); // bit 0 of byte 0
@@ -402,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_get_chunk_at_offset_zero() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         buffer.set_pixel(0, 0, true);
 
         let chunk = buffer.get_chunk(0, 1);
@@ -413,7 +428,7 @@ mod tests {
 
     #[test]
     fn test_get_chunk_multiple_columns() {
-        let buffer = OledBuffer::new();
+        let buffer = OledBuffer::new(128, 64);
 
         let chunk = buffer.get_chunk(0, 10);
         // 10 columns * 8 bytes = 80 bytes
@@ -422,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_get_chunk_at_middle_offset() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         buffer.set_pixel(64, 0, true);
 
         let chunk = buffer.get_chunk(64, 1);
@@ -432,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_get_chunk_preserves_data() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         // Set a pattern in column 5
         buffer.set_pixel(5, 0, true);
         buffer.set_pixel(5, 1, true);
@@ -440,6 +455,52 @@ mod tests {
 
         let chunk = buffer.get_chunk(5, 1);
         assert_eq!(chunk[0], 0b00000111); // bits 0, 1, 2 set
+    }
+
+    // ===========================================
+    // Resolution-aware OledBuffer tests
+    // ===========================================
+
+    #[test]
+    fn test_new_sizes_buffer_for_dimensions() {
+        let b64 = OledBuffer::new(128, 64);
+        assert_eq!(b64.width, 128);
+        assert_eq!(b64.height, 64);
+        assert_eq!(b64.data.len(), 128 * 64 / 8); // 1024
+
+        let b40 = OledBuffer::new(128, 40);
+        assert_eq!(b40.data.len(), 128 * 40 / 8); // 640
+    }
+
+    #[test]
+    fn test_set_pixel_respects_instance_bounds() {
+        let mut b40 = OledBuffer::new(128, 40);
+        b40.set_pixel(0, 39, true); // in bounds
+        b40.set_pixel(0, 40, true); // out of bounds for 40-tall: no-op, no panic
+        b40.set_pixel(127, 0, true);
+        b40.set_pixel(128, 0, true); // no-op
+
+        // (0, 39): column 0, page 4, bit 7
+        assert_eq!(b40.data[4], 0x80);
+        // (127, 0): column 127, page 0, bit 0; 5 pages per column
+        assert_eq!(b40.data[127 * 5], 0x01);
+    }
+
+    #[test]
+    fn test_get_chunk_uses_instance_pages() {
+        let mut b40 = OledBuffer::new(128, 40);
+        b40.set_pixel(2, 0, true);
+        let chunk = b40.get_chunk(0, 4); // 4 columns × 5 pages
+        assert_eq!(chunk.len(), 20);
+        assert_eq!(chunk[2 * 5], 0x01);
+    }
+
+    #[test]
+    fn test_buffer_clone_is_deep() {
+        let mut a = OledBuffer::new(128, 64);
+        a.set_pixel(1, 1, true);
+        let b = a.clone();
+        assert_eq!(a, b);
     }
 
     // ===========================================
@@ -689,7 +750,7 @@ mod tests {
 
     #[test]
     fn test_draw_target_size() {
-        let buffer = OledBuffer::new();
+        let buffer = OledBuffer::new(128, 64);
         let size = buffer.size();
         assert_eq!(size.width, 128);
         assert_eq!(size.height, 64);
@@ -699,7 +760,7 @@ mod tests {
     fn test_draw_target_draw_iter() {
         use embedded_graphics::prelude::*;
 
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         let pixels = vec![
             Pixel(Point::new(10, 10), BinaryColor::On),
             Pixel(Point::new(20, 20), BinaryColor::On),
@@ -720,7 +781,7 @@ mod tests {
 
     #[test]
     fn test_draw_target_ignores_negative_coordinates() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         let pixels = vec![
             Pixel(Point::new(-1, 0), BinaryColor::On),
             Pixel(Point::new(0, -1), BinaryColor::On),
@@ -751,7 +812,7 @@ mod tests {
         let path = dir.join("hwinfo_ss_render_bright.png");
         write_test_image(&path, 4, 4, 255);
 
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         load_image_to_buffer(&path.to_string_lossy(), &mut buffer, 0, 0).unwrap();
 
         // Pixels (0,0)..(3,3) should be on
@@ -767,7 +828,7 @@ mod tests {
         let path = dir.join("hwinfo_ss_render_dark.png");
         write_test_image(&path, 4, 4, 50);
 
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         load_image_to_buffer(&path.to_string_lossy(), &mut buffer, 0, 0).unwrap();
 
         assert!(buffer.data.iter().all(|b| *b == 0));
@@ -782,7 +843,7 @@ mod tests {
         let path = dir.join("hwinfo_ss_render_clip.png");
         write_test_image(&path, 200, 100, 255);
 
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         load_image_to_buffer(&path.to_string_lossy(), &mut buffer, 0, 0).unwrap();
 
         // Buffer length unchanged (no panic from clipping)
@@ -793,7 +854,7 @@ mod tests {
 
     #[test]
     fn test_load_image_to_buffer_missing_file_returns_err() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         let r = load_image_to_buffer("/no/such/path/xyz.png", &mut buffer, 0, 0);
         assert!(r.is_err());
     }
@@ -814,7 +875,7 @@ mod tests {
 
     #[test]
     fn test_draw_target_ignores_out_of_bounds() {
-        let mut buffer = OledBuffer::new();
+        let mut buffer = OledBuffer::new(128, 64);
         let pixels = vec![
             Pixel(Point::new(128, 0), BinaryColor::On),
             Pixel(Point::new(0, 64), BinaryColor::On),

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -110,6 +110,7 @@ impl OledBuffer {
     /// Serialize to SSD1306 page-major order: all columns of page 0, then
     /// page 1, etc. (The internal layout is column-major pages.) Used by the
     /// Apex legacy protocol.
+    #[allow(dead_code)] // consumed by Protocol::ApexLegacy in devices.rs (Task 4)
     pub fn to_page_major(&self) -> Vec<u8> {
         let pages = self.pages();
         let mut out = Vec::with_capacity(self.data.len());
@@ -538,6 +539,8 @@ mod tests {
         assert_eq!(out[0], 0x01);
         assert_eq!(out[128 + 5], 0x02);
         assert_eq!(out[4 * 128 + 127], 0x80);
+        // Exactly the three set pixels are non-zero — no smearing/duplication.
+        assert_eq!(out.iter().filter(|&&b| b != 0).count(), 3);
     }
 
     #[test]

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -111,14 +111,37 @@ impl OledBuffer {
     // clear is omitted as it is currently unused
 
     /// Serialize to SSD1306 page-major order: all columns of page 0, then
-    /// page 1, etc. (The internal layout is column-major pages.) Used by the
-    /// Apex legacy protocol.
+    /// page 1, etc. (The internal layout is column-major pages.)
+    #[allow(dead_code)] // wire format for Apex Gen3 (0x1640/0x1644/0x1646), not yet in the registry
     pub fn to_page_major(&self) -> Vec<u8> {
         let pages = self.pages();
         let mut out = Vec::with_capacity(self.data.len());
         for page in 0..pages {
             for x in 0..self.width as usize {
                 out.push(self.data[x * pages + page]);
+            }
+        }
+        out
+    }
+
+    /// Serialize to row-major MSB-first order: 16 bytes per row for a
+    /// 128-wide screen, the MSB of each byte being the leftmost pixel.
+    /// Wire bitmap format of the Apex legacy keyboards.
+    pub fn to_row_major_msb(&self) -> Vec<u8> {
+        let pages = self.pages();
+        let bytes_per_row = (self.width / 8) as usize;
+        let mut out = Vec::with_capacity(bytes_per_row * self.height as usize);
+        for y in 0..self.height {
+            for byte_x in 0..bytes_per_row {
+                let mut byte = 0u8;
+                for b in 0..8u32 {
+                    let x = byte_x as u32 * 8 + b;
+                    let idx = x as usize * pages + (y / 8) as usize;
+                    if self.data[idx] & (1 << (y % 8)) != 0 {
+                        byte |= 1 << (7 - b);
+                    }
+                }
+                out.push(byte);
             }
         }
         out
@@ -557,6 +580,25 @@ mod tests {
         let out = b.to_page_major();
         assert_eq!(out.len(), 1024);
         assert!(out.iter().all(|&byte| byte == 0));
+    }
+
+    // ===========================================
+    // OledBuffer::to_row_major_msb() tests
+    // ===========================================
+
+    #[test]
+    fn test_to_row_major_msb_length_and_ordering() {
+        let mut b = OledBuffer::new(128, 40);
+        b.set_pixel(0, 0, true); // row 0, byte 0, MSB
+        b.set_pixel(7, 0, true); // row 0, byte 0, LSB
+        b.set_pixel(127, 39, true); // last row, last byte, LSB
+
+        let out = b.to_row_major_msb();
+        assert_eq!(out.len(), 640);
+        assert_eq!(out[0], 0x81); // bits 7 and 0
+        assert_eq!(out[39 * 16 + 15], 0x01);
+        // Exactly two bytes are non-zero.
+        assert_eq!(out.iter().filter(|&&v| v != 0).count(), 2);
     }
 
     // ===========================================

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -1011,6 +1011,8 @@ mod tests {
         // 5 lines of Large font massively overflow 40px; must not panic.
         let buf = render_text_to_oled("A\nB\nC\nD\nE", 0, &[FontSize::Large; 5], 128, 40);
         assert_eq!(buf.data.len(), 640);
+        // Lines A/B fit (Large baselines 16/36 < 40), so content is guaranteed.
+        assert!(buf.data.iter().any(|&b| b != 0));
     }
 
     #[test]

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -130,12 +130,51 @@ impl OriginDimensions for OledBuffer {
     }
 }
 
-// Icon Bitmaps (8x8)
+// Icon Bitmaps (8x8). Each byte is one row, MSB = leftmost pixel.
 const ICON_FIRE: [u8; 8] = [0x18, 0x3c, 0x7e, 0xdb, 0xff, 0xff, 0x7e, 0x3c];
 const ICON_FAN: [u8; 8] = [0x66, 0x66, 0x3c, 0xff, 0xff, 0x3c, 0x66, 0x66];
 const ICON_BOLT: [u8; 8] = [0x08, 0x1c, 0x3e, 0x7f, 0x1e, 0x1c, 0x08, 0x00];
 const ICON_CHART: [u8; 8] = [0x01, 0x03, 0x05, 0x09, 0x11, 0x21, 0x41, 0xff];
 const ICON_DISK: [u8; 8] = [0x7e, 0x81, 0xbd, 0xa5, 0xa5, 0xbd, 0x81, 0x7e];
+const ICON_CPU: [u8; 8] = [0x18, 0x7e, 0x42, 0x5a, 0x5a, 0x42, 0x7e, 0x18];
+const ICON_GPU: [u8; 8] = [0xff, 0x81, 0xbd, 0xa5, 0xbd, 0x81, 0xff, 0x24];
+const ICON_MEM: [u8; 8] = [0x7e, 0xff, 0xdb, 0xdb, 0xdb, 0xff, 0x66, 0x66];
+const ICON_TEMP: [u8; 8] = [0x18, 0x24, 0x24, 0x24, 0x3c, 0x7e, 0x7e, 0x3c];
+const ICON_CLOCK: [u8; 8] = [0x3c, 0x42, 0x89, 0x89, 0x8f, 0x81, 0x42, 0x3c];
+const ICON_NET: [u8; 8] = [0x18, 0x3c, 0x7e, 0x18, 0x18, 0x7e, 0x3c, 0x18];
+
+/// Resolve a builtin icon name (from the per-sensor `icon` config field) to its
+/// 8x8 bitmap. Case-insensitive; surrounding whitespace ignored. Unknown or
+/// empty names return None (no icon drawn). Several names alias the legacy
+/// emoji glyphs so existing artwork is reused.
+pub fn icon_by_name(name: &str) -> Option<&'static [u8; 8]> {
+    match name.trim().to_lowercase().as_str() {
+        "cpu" => Some(&ICON_CPU),
+        "gpu" => Some(&ICON_GPU),
+        "mem" | "ram" => Some(&ICON_MEM),
+        "temp" => Some(&ICON_TEMP),
+        "clock" => Some(&ICON_CLOCK),
+        "net" => Some(&ICON_NET),
+        "fan" => Some(&ICON_FAN),
+        "disk" => Some(&ICON_DISK),
+        "power" | "bolt" => Some(&ICON_BOLT),
+        "usage" | "chart" => Some(&ICON_CHART),
+        "fire" => Some(&ICON_FIRE),
+        _ => None,
+    }
+}
+
+/// Delimiter wrapping an inline icon name inside a display line, e.g.
+/// `"\u{1}cpu\u{1}42°C"`. Uses SOH (U+0001) so it can never collide with a
+/// user label, sensor value, or unit. `format_custom_value` emits these; the
+/// renderer parses them out.
+pub const ICON_DELIM: char = '\u{1}';
+
+/// Wrap a builtin icon name in [`ICON_DELIM`] so it survives line joining and
+/// is recognised by [`render_text_to_oled`].
+pub fn icon_token(name: &str) -> String {
+    format!("{d}{n}{d}", d = ICON_DELIM, n = name)
+}
 
 fn get_emoji_icon(emoji: &str) -> Option<&'static [u8; 8]> {
     if emoji.contains('🔥') {
@@ -175,6 +214,25 @@ pub fn render_text_to_oled(text: &str, x: i32, line_fonts: &[FontSize]) -> OledB
             let path = rest.trim();
             let img_y = (y - 10).max(0) as u32;
             let _ = load_image_to_buffer(path, &mut buffer, current_x as u32, img_y);
+        } else if line.contains(ICON_DELIM) {
+            // Inline icon tokens: text and `\u{1}name\u{1}` icons interleave.
+            // Splitting on the delimiter yields alternating segments — even
+            // indices are text, odd indices are icon names.
+            for (seg_idx, seg) in line.split(ICON_DELIM).enumerate() {
+                if seg_idx % 2 == 1 {
+                    if let Some(icon_data) = icon_by_name(seg) {
+                        let raw_image = ImageRaw::<BinaryColor>::new(icon_data, 8);
+                        let image = Image::new(&raw_image, Point::new(current_x, y - 8));
+                        let _ = image.draw(&mut buffer);
+                        current_x += 10;
+                    }
+                } else if !seg.is_empty() {
+                    current_x = Text::new(seg, Point::new(current_x, y), style)
+                        .draw(&mut buffer)
+                        .map(|next| next.x)
+                        .unwrap_or(current_x);
+                }
+            }
         } else {
             if let Some(icon_data) = get_emoji_icon(line) {
                 let raw_image = ImageRaw::<BinaryColor>::new(icon_data, 8);
@@ -385,6 +443,34 @@ mod tests {
     }
 
     // ===========================================
+    // icon_by_name() tests
+    // ===========================================
+
+    #[test]
+    fn test_icon_by_name_known_builtins_resolve() {
+        for name in [
+            "cpu", "gpu", "mem", "temp", "fan", "clock", "disk", "power", "usage", "net",
+        ] {
+            assert!(
+                icon_by_name(name).is_some(),
+                "builtin icon '{}' should resolve",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_icon_by_name_is_case_insensitive_and_trims() {
+        assert_eq!(icon_by_name("  CPU "), icon_by_name("cpu"));
+    }
+
+    #[test]
+    fn test_icon_by_name_unknown_returns_none() {
+        assert!(icon_by_name("not-an-icon").is_none());
+        assert!(icon_by_name("").is_none());
+    }
+
+    // ===========================================
     // get_emoji_icon() tests
     // ===========================================
 
@@ -441,6 +527,43 @@ mod tests {
         let result = get_emoji_icon("Temperature 🔥");
         assert!(result.is_some());
         assert_eq!(result.unwrap(), &ICON_FIRE);
+    }
+
+    // ===========================================
+    // inline icon token tests
+    // ===========================================
+
+    #[test]
+    fn test_icon_token_roundtrips_with_icon_by_name() {
+        let tok = icon_token("cpu");
+        // The token wraps the name in delimiters so it survives line joining.
+        assert!(tok.starts_with(ICON_DELIM));
+        assert!(tok.ends_with(ICON_DELIM));
+        assert!(tok.contains("cpu"));
+    }
+
+    #[test]
+    fn test_render_inline_icon_token_lights_pixels() {
+        let text = format!("{}Temp", icon_token("cpu"));
+        let buf = render_text_to_oled(&text, 0, &[]);
+        assert!(buf.data.iter().any(|&b| b != 0));
+    }
+
+    #[test]
+    fn test_render_inline_icon_differs_from_plain_text() {
+        let with_icon = render_text_to_oled(&format!("{}42", icon_token("cpu")), 0, &[]);
+        let plain = render_text_to_oled("42", 0, &[]);
+        assert_ne!(with_icon.data, plain.data);
+    }
+
+    #[test]
+    fn test_render_unknown_icon_token_renders_following_text() {
+        // Unknown icon name: no glyph, but the trailing text still renders and
+        // the delimiter chars must not appear as literal glyphs.
+        let with_bogus = render_text_to_oled(&format!("{}Hi", icon_token("bogus")), 0, &[]);
+        let plain = render_text_to_oled("Hi", 0, &[]);
+        assert!(with_bogus.data.iter().any(|&b| b != 0));
+        assert_eq!(with_bogus.data, plain.data);
     }
 
     // ===========================================

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -14,6 +14,11 @@ pub struct CustomSensor {
     pub label: String,
     pub unit: String,
     pub convert: String,
+    /// Builtin icon name drawn before this sensor on the direct-USB OLED
+    /// bitmap (e.g. "cpu", "gpu", "temp"). Empty = no icon. Ignored in
+    /// SteelSeries GG mode. See [`crate::render::icon_by_name`].
+    #[serde(default)]
+    pub icon: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -204,6 +209,8 @@ impl AppConfig {
                                     .get(format!("convert_{}", k))
                                     .unwrap_or("")
                                     .to_string();
+                                let icon =
+                                    section.get(format!("icon_{}", k)).unwrap_or("").to_string();
                                 // Preserve index gaps: empty slots between
                                 // sensors map to flat positions (line * spl +
                                 // slot), so pad up to k before inserting.
@@ -213,6 +220,7 @@ impl AppConfig {
                                         label: String::new(),
                                         unit: String::new(),
                                         convert: String::new(),
+                                        icon: String::new(),
                                     });
                                 }
                                 page_sensors.push(CustomSensor {
@@ -220,6 +228,7 @@ impl AppConfig {
                                     label,
                                     unit,
                                     convert,
+                                    icon,
                                 });
                             }
                         }
@@ -827,6 +836,23 @@ mod tests {
         assert_eq!(config.custom_sensors[1].len(), 1);
         assert_eq!(config.custom_sensors[1][0].sensor, "MEM;Used");
         assert_eq!(config.custom_sensors[1][0].convert, "MB/GB");
+    }
+
+    #[test]
+    fn test_appconfig_loads_icon_from_pages() {
+        let mut conf = Ini::new();
+        conf.with_section(Some("Main"))
+            .set("style", "Custom")
+            .set("pages", "1");
+        conf.with_section(Some("PAGE1.Sensors"))
+            .set("sensor_0", "CPU [#0];Temperature")
+            .set("icon_0", "cpu")
+            .set("sensor_1", "GPU [#0];Temperature"); // no icon_1
+
+        let config = AppConfig::from_ini(&conf).unwrap();
+
+        assert_eq!(config.custom_sensors[0][0].icon, "cpu");
+        assert_eq!(config.custom_sensors[0][1].icon, "");
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -18,6 +18,15 @@ pub struct SensorValue {
     pub value: String,
 }
 
+/// One rendered OLED frame for the GUI: grayscale pixel bytes (0 or 255),
+/// row-major, length = width * height.
+#[derive(Debug, Clone, Serialize)]
+pub struct OledFrame {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct StatusPayload {
     pub hwinfo_connected: bool,
@@ -36,6 +45,8 @@ pub struct SharedState {
     pub last_error: Option<String>,
     pub sensor_values: Vec<SensorValue>,
     pub oled_buffer: OledBuffer,
+    /// Active OLED dimensions (set by the daemon on connect; 128×64 default).
+    pub display_size: (u32, u32),
     pub config: AppConfig,
     pub reload_requested: bool,
     pub sleep_requested: Option<SleepCommand>,
@@ -66,6 +77,7 @@ impl SharedState {
             last_error: None,
             sensor_values: Vec::new(),
             oled_buffer: OledBuffer::new(128, 64),
+            display_size: (128, 64),
             config,
             reload_requested: false,
             sleep_requested: None,
@@ -161,6 +173,25 @@ mod tests {
         assert_eq!(SleepCommand::Sleep, SleepCommand::Sleep);
         assert_ne!(SleepCommand::Sleep, SleepCommand::Wake);
         assert_ne!(SleepCommand::Wake, SleepCommand::White);
+    }
+
+    #[test]
+    fn test_new_initializes_display_size() {
+        let state = SharedState::new(mock_config());
+        assert_eq!(state.display_size, (128, 64));
+    }
+
+    #[test]
+    fn test_oled_frame_serializes() {
+        let f = OledFrame {
+            width: 128,
+            height: 40,
+            pixels: vec![0; 3],
+        };
+        let s = serde_json::to_string(&f).unwrap();
+        assert!(s.contains("\"width\":128"));
+        assert!(s.contains("\"height\":40"));
+        assert!(s.contains("\"pixels\""));
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -40,6 +40,13 @@ pub struct SharedState {
     pub reload_requested: bool,
     pub sleep_requested: Option<SleepCommand>,
     pub hwinfo_snapshot: Option<Hwinfo>,
+    /// Latest media snapshot from the daemon's live `MediaReader`, published each
+    /// tick so the settings preview can render `MEDIA_*` sensors with real data.
+    pub media_info: crate::media::MediaInfo,
+    /// Latest weather snapshot from the daemon's live `WeatherReader`, published
+    /// each tick so the settings preview can render `WEATHER_*` sensors. `None`
+    /// when weather is disabled or no fetch has completed yet.
+    pub weather_info: Option<crate::weather::WeatherInfo>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +70,8 @@ impl SharedState {
             reload_requested: false,
             sleep_requested: None,
             hwinfo_snapshot: None,
+            media_info: crate::media::MediaInfo::default(),
+            weather_info: None,
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -65,7 +65,7 @@ impl SharedState {
             active_mode: ActiveMode::Disconnected,
             last_error: None,
             sensor_values: Vec::new(),
-            oled_buffer: OledBuffer::new(),
+            oled_buffer: OledBuffer::new(128, 64),
             config,
             reload_requested: false,
             sleep_requested: None,

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -160,6 +160,7 @@ pub fn format_custom_value(
     labels: Vec<&str>,
     values: Vec<String>,
     units: Vec<&str>,
+    icons: Vec<&str>,
 ) -> Value {
     let mut value = json!({});
 
@@ -170,12 +171,21 @@ pub fn format_custom_value(
                 let idx = start_idx + i;
                 let label = labels[idx].trim();
                 let unit = units[idx].trim();
+                let icon = icons[idx].trim();
+
+                // Leading icon token (rendered only on the direct-USB bitmap
+                // path; ignored as a harmless control char by GameSense text).
+                let prefix = if icon.is_empty() {
+                    String::new()
+                } else {
+                    crate::render::icon_token(icon)
+                };
 
                 // Format with proper spacing: add space between label and value only if label exists
                 if label.is_empty() {
-                    format!("{}{}", values[idx], unit)
+                    format!("{}{}{}", prefix, values[idx], unit)
                 } else {
-                    format!("{} {}{}", label, values[idx], unit)
+                    format!("{}{} {}{}", prefix, label, values[idx], unit)
                 }
             })
             .collect();
@@ -997,6 +1007,37 @@ mod tests {
     }
 
     #[test]
+    fn test_format_custom_value_prepends_icon_token_when_set() {
+        let mut labels = vec![""; 15];
+        labels[0] = "CPU";
+        let mut values = vec![String::new(); 15];
+        values[0] = "42".to_string();
+        let units = vec![""; 15];
+        let mut icons = vec![""; 15];
+        icons[0] = "cpu";
+
+        let result = format_custom_value(1, labels, values, units, icons);
+
+        let line1 = result["line1"].as_str().unwrap();
+        assert!(line1.starts_with(&crate::render::icon_token("cpu")));
+        assert!(line1.contains("CPU 42"));
+    }
+
+    #[test]
+    fn test_format_custom_value_no_token_when_icon_empty() {
+        let mut labels = vec![""; 15];
+        labels[0] = "CPU";
+        let mut values = vec![String::new(); 15];
+        values[0] = "42".to_string();
+        let units = vec![""; 15];
+        let icons = vec![""; 15];
+
+        let result = format_custom_value(1, labels, values, units, icons);
+
+        assert_eq!(result["line1"], "CPU 42");
+    }
+
+    #[test]
     fn test_format_custom_value_one_sensor_per_line() {
         let labels = ["L1", "L2", "L3", "L4", "L5"];
         let mut all_labels = vec![""; 15];
@@ -1020,7 +1061,7 @@ mod tests {
             all_units[i] = u;
         }
 
-        let result = format_custom_value(1, all_labels, all_values, all_units);
+        let result = format_custom_value(1, all_labels, all_values, all_units, vec![""; 15]);
 
         assert_eq!(result["line1"], "L1 1U1");
         assert_eq!(result["line2"], "L2 2U2");
@@ -1039,7 +1080,7 @@ mod tests {
             *v = i.to_string();
         }
 
-        let result = format_custom_value(3, labels, values, units);
+        let result = format_custom_value(3, labels, values, units, vec![""; 15]);
 
         assert_eq!(result["line1"], "0 1 2");
         assert_eq!(result["line2"], "3 4 5");

--- a/src-tauri/src/weather.rs
+++ b/src-tauri/src/weather.rs
@@ -426,8 +426,8 @@ impl WeatherReader {
         }
     }
 
-    /// Test-only constructor with a pre-populated cache.
-    #[cfg(test)]
+    /// Constructor with a pre-populated cache and no refresh thread. Used by the
+    /// settings preview to render `WEATHER_*` sensors with the daemon's live data.
     pub fn with_cached_info(info: WeatherInfo) -> Self {
         Self {
             shared: Arc::new(RwLock::new(Some(info))),
@@ -468,6 +468,13 @@ impl WeatherReader {
     /// has been fetched yet, or the field is unset.
     pub fn get_field(&self, field: WeatherField) -> Option<String> {
         self.shared.read().ok()?.as_ref()?.get(field)
+    }
+
+    /// Clone the current cached `WeatherInfo`, if any. The daemon publishes this
+    /// into shared state each tick so the GUI preview can seed a reader via
+    /// `with_cached_info`.
+    pub fn current_info(&self) -> Option<WeatherInfo> {
+        self.shared.read().ok()?.clone()
     }
 }
 

--- a/src-tauri/ui/index.html
+++ b/src-tauri/ui/index.html
@@ -465,8 +465,12 @@
             if (!frame || !frame.pixels || frame.pixels.length !== frame.width * frame.height) return;
             if (previewCanvas.width !== frame.width) previewCanvas.width = frame.width;
             if (previewCanvas.height !== frame.height) previewCanvas.height = frame.height;
-            document.getElementById('preview-caption').textContent =
-                `What is currently on the OLED (${frame.width}×${frame.height})`;
+            // Refresh the trailing (W×H) suffix without clobbering the
+            // caller-set caption ("Editing preview (page N)" / live text).
+            const caption = document.getElementById('preview-caption');
+            caption.textContent =
+                caption.textContent.replace(/\s*\(\d+×\d+\)$/, '') +
+                ` (${frame.width}×${frame.height})`;
             const imgData = previewCtx.createImageData(frame.width, frame.height);
             for (let i = 0; i < frame.pixels.length; i++) {
                 const v = frame.pixels[i];

--- a/src-tauri/ui/index.html
+++ b/src-tauri/ui/index.html
@@ -1031,10 +1031,12 @@
                 select.appendChild(opt);
             }
 
-            // Select the currently configured serial if it's in the list
+            // Select the currently configured serial if it's in the list and
+            // selectable; a disabled option (unsupported device) falls back to
+            // Auto rather than programmatically selecting an unpickable entry.
             const wanted = config.direct_usb_serial || '';
             const found = Array.from(select.options).find(o => o.value === wanted);
-            select.value = found ? wanted : '';
+            select.value = (found && !found.disabled) ? wanted : '';
         }
 
         document.getElementById('pages').addEventListener('change', () => {

--- a/src-tauri/ui/index.html
+++ b/src-tauri/ui/index.html
@@ -127,7 +127,7 @@
 
         #oled-preview {
             width: 384px;
-            height: 192px;
+            height: auto;
             image-rendering: pixelated;
             background-color: #111;
         }
@@ -461,11 +461,15 @@
         const previewCtx = previewCanvas.getContext('2d');
 
         // --- Preview rendering ---
-        function renderFrame(pixels) {
-            if (!pixels || pixels.length !== 128 * 64) return;
-            const imgData = previewCtx.createImageData(128, 64);
-            for (let i = 0; i < pixels.length; i++) {
-                const v = pixels[i];
+        function renderFrame(frame) {
+            if (!frame || !frame.pixels || frame.pixels.length !== frame.width * frame.height) return;
+            if (previewCanvas.width !== frame.width) previewCanvas.width = frame.width;
+            if (previewCanvas.height !== frame.height) previewCanvas.height = frame.height;
+            document.getElementById('preview-caption').textContent =
+                `What is currently on the OLED (${frame.width}×${frame.height})`;
+            const imgData = previewCtx.createImageData(frame.width, frame.height);
+            for (let i = 0; i < frame.pixels.length; i++) {
+                const v = frame.pixels[i];
                 imgData.data[i * 4] = v;
                 imgData.data[i * 4 + 1] = v;
                 imgData.data[i * 4 + 2] = v;
@@ -1002,7 +1006,9 @@
                 // platform HID path (prefixed so the backend can tell them apart)
                 // when the device does not expose a serial.
                 opt.value = d.serial ? d.serial : (d.path ? `path:${d.path}` : '');
-                const label = d.product || `Unknown device ${d.product_id.toString(16)}`;
+                const label = (d.supported && d.device_name)
+                    ? d.device_name
+                    : (d.product || `Unknown device ${d.product_id.toString(16)}`);
                 let tail;
                 if (d.serial) {
                     tail = ` — ${d.serial.slice(0, 12)}`;
@@ -1013,6 +1019,10 @@
                     tail = ' — (no serial)';
                 }
                 opt.textContent = `${label} [PID 0x${d.product_id.toString(16).padStart(4, '0')}, if ${d.interface_number}]${tail}`;
+                if (!d.supported) {
+                    opt.disabled = true;
+                    opt.textContent += ' — not yet supported';
+                }
                 if (!d.serial && !d.path) opt.disabled = true;
                 select.appendChild(opt);
             }

--- a/src-tauri/ui/index.html
+++ b/src-tauri/ui/index.html
@@ -449,6 +449,13 @@
         let editingDraft = null;           // {sensor, label, unit, convert}
 
         const UNIT_SUGGESTIONS = ['°', '°C', '%', 'G', 'GB', 'MB', 'W', 'RPM', 'V', 'MHz', 'rpm'];
+        // Builtin icons drawn before the value in Direct USB mode. Values must
+        // match render::icon_by_name on the backend.
+        const ICON_OPTIONS = [
+            ['', 'None'], ['cpu', 'CPU'], ['gpu', 'GPU'], ['mem', 'Memory'],
+            ['temp', 'Temperature'], ['fan', 'Fan'], ['clock', 'Clock'],
+            ['disk', 'Disk'], ['power', 'Power'], ['usage', 'Usage'], ['net', 'Network'],
+        ];
 
         const previewCanvas = document.getElementById('oled-preview');
         const previewCtx = previewCanvas.getContext('2d');
@@ -516,7 +523,7 @@
             ensurePage(page);
             const idx = line * (config.sensors_per_line || 1) + slot;
             while (config.custom_sensors[page].length <= idx) {
-                config.custom_sensors[page].push({ sensor: '', label: '', unit: '', convert: '' });
+                config.custom_sensors[page].push({ sensor: '', label: '', unit: '', convert: '', icon: '' });
             }
             config.custom_sensors[page][idx] = value;
         }
@@ -524,7 +531,7 @@
             ensurePage(page);
             const idx = line * (config.sensors_per_line || 1) + slot;
             if (config.custom_sensors[page][idx]) {
-                config.custom_sensors[page][idx] = { sensor: '', label: '', unit: '', convert: '' };
+                config.custom_sensors[page][idx] = { sensor: '', label: '', unit: '', convert: '', icon: '' };
             }
         }
 
@@ -609,8 +616,8 @@
         async function openSlotForm(line, slot) {
             const existing = getSlot(activePage, line, slot);
             editingDraft = existing
-                ? { sensor: existing.sensor, label: existing.label, unit: existing.unit, convert: existing.convert }
-                : { sensor: '', label: '', unit: '', convert: '' };
+                ? { sensor: existing.sensor, label: existing.label, unit: existing.unit, convert: existing.convert, icon: existing.icon || '' }
+                : { sensor: '', label: '', unit: '', convert: '', icon: '' };
             editingSlot = { line, slot };
             // Always refresh catalog when opening form
             await loadSensorCatalog();
@@ -698,6 +705,24 @@
             cSelect.onchange = (e) => { editingDraft.convert = e.target.value; };
             convRow.appendChild(cSelect);
             form.appendChild(convRow);
+
+            // Icon (direct-USB bitmap path only; ignored in SteelSeries GG mode)
+            const iconRow = document.createElement('div');
+            iconRow.className = 'slot-form-row';
+            const iLabel = document.createElement('label');
+            iLabel.textContent = 'Icon';
+            iconRow.appendChild(iLabel);
+            const iSelect = document.createElement('select');
+            ICON_OPTIONS.forEach(([val, lab]) => {
+                const opt = document.createElement('option');
+                opt.value = val;
+                opt.textContent = lab;
+                if ((editingDraft.icon || '') === val) opt.selected = true;
+                iSelect.appendChild(opt);
+            });
+            iSelect.onchange = (e) => { editingDraft.icon = e.target.value; };
+            iconRow.appendChild(iSelect);
+            form.appendChild(iconRow);
 
             // Actions
             const actions = document.createElement('div');


### PR DESCRIPTION
## Summary
- Adds a static supported-device registry (`devices.rs`) for direct-USB mode: each entry carries PID(s), screen dimensions, and a packet protocol. Seeded with Arctis Nova Pro Wireless (128×64, two 1024-byte feature reports) and the five legacy Apex OLED keyboards (128×40, one 642-byte report: `0x61` + row-major MSB-first bitmap + pad).
- `OledBuffer`/renderer/previews are now resolution-aware end to end; frame payloads carry `{width, height, pixels}` and the GUI canvas adapts.
- Connect refuses SteelSeries OLED devices that are not in the registry with a named error surfaced in GUI status ("Detected X (PID 0x….) — not yet supported for direct USB"); the device picker lists them greyed out. Wrong-packets-to-wrong-device is impossible by construction.

## Notes
- Nova Pro wire bytes are unchanged (locked in by golden packet tests) and verified on hardware: `Direct USB device: Arctis Nova Pro Wireless (128x64)`.
- Apex legacy format is verified against apex-tux source (`apex-hardware/src/{usb,device}.rs`); on-hardware verification pending until an Apex keyboard is available.
- Design spec: `docs/superpowers/specs/2026-06-11-usb-device-registry-design.md`; plan: `docs/superpowers/plans/2026-06-11-usb-device-registry.md`.

## Test Plan
- [x] 519 bin tests pass (`cargo test --bins`); the one failing test asserts HWiNFO connection *fails* and is environment-dependent (HWiNFO running on the dev machine)
- [x] `cargo clippy --bins -- -D warnings` and `cargo fmt` clean
- [x] On-hardware sanity: new build connects to live Nova Pro Wireless via registry, renders for 12s without errors
- [ ] On-hardware Apex verification when hardware available

🤖 Generated with [Claude Code](https://claude.com/claude-code)